### PR TITLE
Add revision links and activate build server integration

### DIFF
--- a/GitExtensions.settings
+++ b/GitExtensions.settings
@@ -1,0 +1,116 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<dictionary>
+  <item>
+    <key>
+      <string>BuildServer.AppVeyor.AppVeyorDisplayGitHubPullRequests</string>
+    </key>
+    <value>
+      <string>false</string>
+    </value>
+  </item>
+  <item>
+    <key>
+      <string>BuildServer.AppVeyor.AppVeyorLoadTestsResults</string>
+    </key>
+    <value>
+      <string>false</string>
+    </value>
+  </item>
+  <item>
+    <key>
+      <string>BuildServer.AppVeyor.AppVeyorProjectName</string>
+    </key>
+    <value>
+      <string>gitextensions/gitextensions-pluginmanager</string>
+    </value>
+  </item>
+  <item>
+    <key>
+      <string>BuildServer.EnableIntegration</string>
+    </key>
+    <value>
+      <string>true</string>
+    </value>
+  </item>
+  <item>
+    <key>
+      <string>BuildServer.Type</string>
+    </key>
+    <value>
+      <string>AppVeyor</string>
+    </value>
+  </item>
+  <item>
+    <key>
+      <string>dictionary</string>
+    </key>
+    <value>
+      <string>en-US</string>
+    </value>
+  </item>
+  <item>
+    <key>
+      <string>RevisionLinkDefs</string>
+    </key>
+    <value>
+      <string>&lt;?xml version="1.0" encoding="utf-16"?&gt;
+&lt;ArrayOfGitExtLinkDef&gt;
+  &lt;GitExtLinkDef&gt;
+    &lt;Enabled&gt;true&lt;/Enabled&gt;
+    &lt;LinkFormats&gt;
+      &lt;GitExtLinkFormat&gt;
+        &lt;Caption&gt;View on GitHub&lt;/Caption&gt;
+        &lt;Format&gt;https://github.com/gitextensions/gitextensions.pluginmanager/commit/%COMMIT_HASH%&lt;/Format&gt;
+      &lt;/GitExtLinkFormat&gt;
+    &lt;/LinkFormats&gt;
+    &lt;Name&gt;GitHub - commit&lt;/Name&gt;
+    &lt;NestedSearchPattern /&gt;
+    &lt;RemoteSearchInParts /&gt;
+    &lt;SearchInParts&gt;
+      &lt;RevisionPart&gt;Message&lt;/RevisionPart&gt;
+    &lt;/SearchInParts&gt;
+    &lt;SearchPattern&gt;.*&lt;/SearchPattern&gt;
+    &lt;UseOnlyFirstRemote&gt;false&lt;/UseOnlyFirstRemote&gt;
+  &lt;/GitExtLinkDef&gt;
+  &lt;GitExtLinkDef&gt;
+    &lt;Enabled&gt;true&lt;/Enabled&gt;
+    &lt;LinkFormats&gt;
+      &lt;GitExtLinkFormat&gt;
+        &lt;Caption&gt;Issue {0}&lt;/Caption&gt;
+        &lt;Format&gt;https://github.com/gitextensions/gitextensions.pluginmanager/issues/{0}&lt;/Format&gt;
+      &lt;/GitExtLinkFormat&gt;
+    &lt;/LinkFormats&gt;
+    &lt;Name&gt;GitHub - issues&lt;/Name&gt;
+    &lt;NestedSearchPattern&gt;\d+&lt;/NestedSearchPattern&gt;
+    &lt;RemoteSearchInParts /&gt;
+    &lt;SearchInParts&gt;
+      &lt;RevisionPart&gt;Message&lt;/RevisionPart&gt;
+      &lt;RevisionPart&gt;LocalBranches&lt;/RevisionPart&gt;
+      &lt;RevisionPart&gt;RemoteBranches&lt;/RevisionPart&gt;
+    &lt;/SearchInParts&gt;
+    &lt;SearchPattern&gt;(?i)(?&amp;lt;!pull request |pr[ _]?)(#|(((feat(ure)?)|fix)[/_-]))\d+&lt;/SearchPattern&gt;
+    &lt;UseOnlyFirstRemote&gt;false&lt;/UseOnlyFirstRemote&gt;
+  &lt;/GitExtLinkDef&gt;
+  &lt;GitExtLinkDef&gt;
+    &lt;Enabled&gt;true&lt;/Enabled&gt;
+    &lt;LinkFormats&gt;
+      &lt;GitExtLinkFormat&gt;
+        &lt;Caption&gt;PR {0}&lt;/Caption&gt;
+        &lt;Format&gt;https://github.com/gitextensions/gitextensions.pluginmanager/pull/{0}&lt;/Format&gt;
+      &lt;/GitExtLinkFormat&gt;
+    &lt;/LinkFormats&gt;
+    &lt;Name&gt;GitHub - PR&lt;/Name&gt;
+    &lt;NestedSearchPattern&gt;\d+&lt;/NestedSearchPattern&gt;
+    &lt;RemoteSearchInParts /&gt;
+    &lt;SearchInParts&gt;
+      &lt;RevisionPart&gt;Message&lt;/RevisionPart&gt;
+      &lt;RevisionPart&gt;LocalBranches&lt;/RevisionPart&gt;
+      &lt;RevisionPart&gt;RemoteBranches&lt;/RevisionPart&gt;
+    &lt;/SearchInParts&gt;
+    &lt;SearchPattern&gt;(?i)(pull request |pr[ _]?)#?\d+&lt;/SearchPattern&gt;
+    &lt;UseOnlyFirstRemote&gt;false&lt;/UseOnlyFirstRemote&gt;
+  &lt;/GitExtLinkDef&gt;
+&lt;/ArrayOfGitExtLinkDef&gt;</string>
+    </value>
+  </item>
+</dictionary>


### PR DESCRIPTION
## Proposed changes

* add `GitExtensions.settings` file to provide directly in GE:
  * revision links to the repo on GitHub
  * status from the AppVeyor build server

![image](https://user-images.githubusercontent.com/46861028/59541452-a2c3f000-8f01-11e9-9b87-97e9c9fd2802.png)

