### PR TITLE
bump version number and update versioning scheme

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,16 +1,64 @@
-version: '{build}'
+#---------------------------------#
+#      general configuration      #
+#---------------------------------#
 
-image: Visual Studio 2017
+# version format
+version: 1.0.0.{build}
+
+# version suffix, if any (e.g. '-RC1', '-beta' otherwise '')
+environment:
+  version_suffix: '-RC1'
+
+# Do not build on tags (GitHub and BitBucket)
+skip_tags: true
+
+# Maximum number of concurrent jobs for the project
+max_jobs: 1
+
+#---------------------------------#
+#    environment configuration    #
+#---------------------------------#
+
+# Build worker image (VM template)
+image:
+- Visual Studio 2017
+- Visual Studio 2019
+
+# enable patching of Directory.Build.props
+dotnet_csproj:
+  patch: true
+  file: '**\*.props'
+  version: '{version}'
+  assembly_version: '{version}'
+  file_version: '{version}'
+  informational_version: '{version}$(version_suffix)'
+  package_version: '{version}$(version_suffix)'
+
+#---------------------------------#
+#       build configuration       #
+#---------------------------------#
 
 build_script:
 - ps: .\tools\Prepare-Release.ps1
 
+#---------------------------------#
+#       tests configuration       #
+#---------------------------------#
+
 test_script:
 - ps: .\tools\Run-Tests.ps1
+
+#---------------------------------#
+#      artifacts configuration    #
+#---------------------------------#
 
 artifacts:
 - path: .\*.zip
 - path: .\*.nupkg
+
+#---------------------------------#
+#     deployment configuration    #
+#---------------------------------#
 
 # Commented out as we need to create a new signing policy.
 # deploy:

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,13 +1,14 @@
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  
+<!-- Do not use XML namespaces here (<Project xmlns="...">), because it would break patching of version numbers during builds on AppVeyor (https://github.com/appveyor/website/pull/409) -->
+<Project>
   <PropertyGroup>
     <Authors>Git Extensions</Authors>
     <Company>Git Extensions</Company>
     <RepositoryUrl>https://github.com/gitextensions/gitextensions.pluginmanager</RepositoryUrl>
     <LangVersion>latest</LangVersion>
-
-    <VersionPrefix>0.9.0</VersionPrefix>
-    <VersionSuffix></VersionSuffix>
+    <Version>0.0.0</Version>
+    <AssemblyVersion>0.0.0.1</AssemblyVersion>
+    <FileVersion>0.0.0.1</FileVersion>
+    <InformationalVersion>0.0.0.1</InformationalVersion>
+    <PackageVersion>0.0.0.1</PackageVersion>
   </PropertyGroup>
-
 </Project>

--- a/src/GitExtensions.PluginManager/GitExtensions.PluginManager.csproj
+++ b/src/GitExtensions.PluginManager/GitExtensions.PluginManager.csproj
@@ -16,6 +16,7 @@
     <GitExtensionsDebugPluginsPath>..\..\references\GitExtensions\UserPlugins\</GitExtensionsDebugPluginsPath>
     <GitExtensionsReferenceSource>appveyor</GitExtensionsReferenceSource>
     <GitExtensionsReferenceVersion>v3.2.0.5938</GitExtensionsReferenceVersion>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tools/Prepare-Release.ps1
+++ b/tools/Prepare-Release.ps1
@@ -3,42 +3,24 @@ Push-Location $PSScriptRoot;
 $targetPath = '..\';
 
 $isAppveyor = $True -eq $env:APPVEYOR;
-$isTag = 'true' -eq $env:APPVEYOR_REPO_TAG;
 
 If (!$isAppveyor)
 {
     Write-Host "Running a local build";
 
     $targetPath = Join-Path $targetPath 'artifacts';
-    $versionSuffix = $Null;
-}
-Elseif (!$isTag)
-{
-    Write-Host "Running an Appveyor commit build";
-
-    $buildNumber = "build{0:D4}" -f [convert]::ToInt32($env:APPVEYOR_BUILD_NUMBER, 10);
-    $commitHash = ($env:APPVEYOR_REPO_COMMIT).Substring(0, 10);
-    $versionSuffix = $buildNumber + "+" + $commitHash;
-
-    Write-Host ("Version suffix: " + $versionSuffix);
-}
-Else
-{
-    Write-Host ("Running an Appveyor release (tag '" + $env:APPVEYOR_REPO_TAG_NAME + "') build");
-
-    $versionSuffix = $null;
 }
 
 dotnet restore ..\GitExtensions.PluginManager.sln
 
-msbuild ..\GitExtensions.PluginManager.sln /p:Configuration=Release -property:VersionSuffix=$versionSuffix -verbosity:minimal
+msbuild ..\GitExtensions.PluginManager.sln /p:Configuration=Release -verbosity:minimal
 if (!($LastExitCode -eq 0))
 {
     Write-Error -Message "MSBuild failed with $LastExitCode" -ErrorAction Stop
 }
 
 $packPath = Join-Path ".." $targetPath;
-dotnet pack ..\src\GitExtensions.PluginManager -c Release -o $packPath --no-build /p:VersionSuffix=$versionSuffix
+dotnet pack ..\src\GitExtensions.PluginManager -c Release -o $packPath --no-build
 
 Copy-Item ..\src\GitExtensions.PluginManager\bin\Release\*.zip $targetPath
 


### PR DESCRIPTION
## Proposed changes

* set version number to `1.0.0.{build}-RC1`
* move "master" version number (the one everything depends on) from `Directory.Build.props` into `appveyor.yml`
* change version format to `MAJOR.MINOR.PATCH.BUILD[-SUFFIX]`
* minor tweaks in `appveyor.yml`, mostly comments (apart from the version format)