### PR TITLE
Disable PM auto update

### DIFF
--- a/src/PackageManager.UI/App.xaml.cs
+++ b/src/PackageManager.UI/App.xaml.cs
@@ -100,8 +100,10 @@ namespace PackageManager
 
             wnd.Show();
 
+            /*
             if (Args.IsSelfUpdate)
                 RunSelfUpdate(wnd);
+            */
         }
 
         private void BuildExceptionHandler()


### PR DESCRIPTION
Resolves #20 

## Proposed changes

* Disable auto update functionality. This is a temporary fix for v1.0.0.
It is needed, because the current implementation would search for any package named `GitExtensions.PluginManager` with version number > 1.0.0 on nuget.org and try to install it. Since this package does not exist (and we don't want to create it on nuget.org), anybody could create it and trigger the update mechanism.
A more robust and permanent fix will be implemented in #19.