### PR TITLE
Repo maintenance

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,5 +1,4 @@
 # These are supported funding model platforms
 
-github: russkie, gerhardol, maraf, mast-eu # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
 open_collective: gitextensions
 custom: https://github.com/gitextensions/gitextensions/wiki

--- a/.gitignore
+++ b/.gitignore
@@ -290,3 +290,6 @@ __pycache__/
 
 references/
 *.zip
+
+# Git Extensions specific files
+GitExtensions.settings.backup

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,6 @@ max_jobs: 1
 
 # Build worker image (VM template)
 image:
-- Visual Studio 2017
 - Visual Studio 2019
 
 # enable patching of Directory.Build.props


### PR DESCRIPTION
## Proposed changes 

- Add GitExtensions.settings.backup to .gitignore
- Remove VS2017 from CI
- Remove users not enrolled in GitHub Sponsors to avoid the following error message when clicking on the sponsor button.
![image](https://user-images.githubusercontent.com/46861028/62417106-0b009980-b648-11e9-8db7-a6f7c96cb1b4.png)

