### PR TITLE
Search by tags

### DIFF
--- a/src/GitExtensions.PluginManager/Plugin.cs
+++ b/src/GitExtensions.PluginManager/Plugin.cs
@@ -52,6 +52,7 @@ namespace GitExtensions.PluginManager
             Args args = new Args();
             args.Path = pluginsPath;
             args.Dependencies = new List<Args.Dependency>() { new Args.Dependency("GitExtensions.Extensibility") };
+            args.Tags = "GitExtensions";
             args.Monikers = FrameworkMonikers;
             args.SelfPackageId = PackageId;
             args.ProcessNamesToKillBeforeChange = new[] { Process.GetCurrentProcess().ProcessName };

--- a/src/GitExtensions.PluginManager/PluginSettings.cs
+++ b/src/GitExtensions.PluginManager/PluginSettings.cs
@@ -20,7 +20,7 @@ namespace GitExtensions.PluginManager
         /// <summary>
         /// Gets current value of <see cref="CloseInstancesProperty"/>.
         /// </summary>
-        public bool CloseInstances => source.GetValue(CloseInstancesProperty.Name, CloseInstancesProperty.DefaultValue, t => Boolean.Parse(t));
+        public bool CloseInstances => source.GetValue(CloseInstancesProperty.Name, CloseInstancesProperty.DefaultValue, t => bool.Parse(t));
 
         public PluginSettings(ISettingsSource source)
         {

--- a/src/PackageManager.Cli/Args.cs
+++ b/src/PackageManager.Cli/Args.cs
@@ -105,16 +105,16 @@ namespace PackageManager
         {
             StringBuilder result = new StringBuilder();
 
-            if (!String.IsNullOrEmpty(Path))
+            if (!string.IsNullOrEmpty(Path))
                 result.Append($"--path \"{Path}\"");
 
-            if (!String.IsNullOrEmpty(SelfPackageId))
+            if (!string.IsNullOrEmpty(SelfPackageId))
                 result.Append($" --selfpackageid {SelfPackageId}");
 
             if (IsSelfUpdate)
                 result.Append(" --selfupdate");
 
-            if (!String.IsNullOrEmpty(SelfOriginalPath))
+            if (!string.IsNullOrEmpty(SelfOriginalPath))
                 result.Append($" --selforiginalpath \"{SelfOriginalPath}\"");
 
             return result.ToString();

--- a/src/PackageManager.Cli/Program.cs
+++ b/src/PackageManager.Cli/Program.cs
@@ -40,7 +40,7 @@ namespace PackageManager.Cli
                 UpdatesViewModel viewModel = CreateUpdatesViewModel();
                 await viewModel.Refresh.ExecuteAsync();
 
-                PackageUpdateViewModel packageModel = viewModel.Packages.FirstOrDefault(p => p.Target.Id == Args.PackageId);
+                PackageUpdateViewModel packageModel = viewModel.Packages.FirstOrDefault(p => string.Equals(p.Target.Id, Args.PackageId, StringComparison.CurrentCultureIgnoreCase));
                 if (packageModel != null && viewModel.Update.CanExecute(packageModel))
                 {
                     await viewModel.Update.ExecuteAsync(packageModel);

--- a/src/PackageManager.NuGet/Models/NuGetPackage.cs
+++ b/src/PackageManager.NuGet/Models/NuGetPackage.cs
@@ -49,7 +49,7 @@ namespace PackageManager.Models
             => await contentService.DownloadAsync(repository, source, cancellationToken);
 
         public async Task<IEnumerable<IPackage>> GetVersionsAsync(bool isPrereleaseIncluded, CancellationToken cancellationToken)
-            => await versionService.GetListAsync(Int32.MaxValue, source, repository, isPrereleaseIncluded: isPrereleaseIncluded, cancellationToken: cancellationToken);
+            => await versionService.GetListAsync(int.MaxValue, source, repository, isPrereleaseIncluded: isPrereleaseIncluded, cancellationToken: cancellationToken);
 
         public bool Equals(IPackage other)
             => Equals((IPackageIdentity)other);

--- a/src/PackageManager.NuGet/Models/NuGetPackageIdentity.cs
+++ b/src/PackageManager.NuGet/Models/NuGetPackageIdentity.cs
@@ -26,7 +26,7 @@ namespace PackageManager.Models
             if (other == null)
                 return false;
 
-            return Id == other.Id && Version == other.Version;
+            return string.Equals(Id, other.Id, StringComparison.CurrentCultureIgnoreCase) && string.Equals(Version, other.Version, StringComparison.CurrentCultureIgnoreCase);
         }
     }
 }

--- a/src/PackageManager.NuGet/Models/NuGetPackageSourceCollection.cs
+++ b/src/PackageManager.NuGet/Models/NuGetPackageSourceCollection.cs
@@ -17,7 +17,7 @@ namespace PackageManager.Models
 
         public event Action Changed;
 
-        public IPackageSource Primary => Sources.FirstOrDefault(s => s.Name == Provider.ActivePackageSourceName);
+        public IPackageSource Primary => Sources.FirstOrDefault(s => string.Equals(s.Name, Provider.ActivePackageSourceName, StringComparison.CurrentCultureIgnoreCase));
         public IReadOnlyCollection<IPackageSource> All => Sources;
 
         public NuGetPackageSourceCollection(INuGetPackageSourceProvider provider)
@@ -66,7 +66,7 @@ namespace PackageManager.Models
 
         public void MarkAsPrimary(IPackageSource source)
         {
-            if (Provider.ActivePackageSourceName == source?.Name)
+            if (string.Equals(Provider.ActivePackageSourceName, source?.Name, StringComparison.CurrentCultureIgnoreCase))
                 return;
 
             if (source == null)

--- a/src/PackageManager.NuGet/Services/EmptyNuGetSearchTermTransformer.cs
+++ b/src/PackageManager.NuGet/Services/EmptyNuGetSearchTermTransformer.cs
@@ -13,28 +13,6 @@ namespace PackageManager.Services
         {
         }
 
-        #region Singleton
-
-        private static EmptyNuGetSearchTermTransformer instance;
-        private static object instanceLock = new object();
-
-        public static EmptyNuGetSearchTermTransformer Instance
-        {
-            get
-            {
-                if (instance == null)
-                {
-                    lock (instanceLock)
-                    {
-                        if (instance == null)
-                            instance = new EmptyNuGetSearchTermTransformer();
-                    }
-                }
-
-                return instance;
-            }
-        }
-
-        #endregion
+        public readonly static EmptyNuGetSearchTermTransformer Instance = new EmptyNuGetSearchTermTransformer();
     }
 }

--- a/src/PackageManager.NuGet/Services/EmptyNuGetSearchTermTransformer.cs
+++ b/src/PackageManager.NuGet/Services/EmptyNuGetSearchTermTransformer.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PackageManager.Services
+{
+    public class EmptyNuGetSearchTermTransformer : INuGetSearchTermTransformer
+    {
+        public string Transform(string searchTerm) => searchTerm;
+
+        #region Singleton
+
+        private static EmptyNuGetSearchTermTransformer instance;
+        private static object instanceLock = new object();
+
+        public static EmptyNuGetSearchTermTransformer Instance
+        {
+            get
+            {
+                if (instance == null)
+                {
+                    lock (instanceLock)
+                    {
+                        if (instance == null)
+                            instance = new EmptyNuGetSearchTermTransformer();
+                    }
+                }
+
+                return instance;
+            }
+        }
+
+        #endregion
+    }
+}

--- a/src/PackageManager.NuGet/Services/EmptyNuGetSearchTermTransformer.cs
+++ b/src/PackageManager.NuGet/Services/EmptyNuGetSearchTermTransformer.cs
@@ -9,7 +9,9 @@ namespace PackageManager.Services
 {
     public class EmptyNuGetSearchTermTransformer : INuGetSearchTermTransformer
     {
-        public string Transform(string searchTerm) => searchTerm;
+        public void Transform(NuGetSearchTerm searchTerm)
+        {
+        }
 
         #region Singleton
 

--- a/src/PackageManager.NuGet/Services/INuGetPackageFilter.cs
+++ b/src/PackageManager.NuGet/Services/INuGetPackageFilter.cs
@@ -3,12 +3,13 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace PackageManager.Services
 {
     public interface INuGetPackageFilter
     {
-        NuGetPackageFilterResult IsPassed(IPackageSearchMetadata package);
+        Task<NuGetPackageFilterResult> IsPassedAsync(SourceRepository repository, IPackageSearchMetadata package, CancellationToken cancellationToken);
     }
 }

--- a/src/PackageManager.NuGet/Services/INuGetPackageFilter.cs
+++ b/src/PackageManager.NuGet/Services/INuGetPackageFilter.cs
@@ -10,6 +10,6 @@ namespace PackageManager.Services
 {
     public interface INuGetPackageFilter
     {
-        Task<NuGetPackageFilterResult> IsPassedAsync(SourceRepository repository, IPackageSearchMetadata package, CancellationToken cancellationToken);
+        Task<NuGetPackageFilterResult> FilterAsync(SourceRepository repository, IPackageSearchMetadata package, CancellationToken cancellationToken);
     }
 }

--- a/src/PackageManager.NuGet/Services/INuGetSearchTermTransformer.cs
+++ b/src/PackageManager.NuGet/Services/INuGetSearchTermTransformer.cs
@@ -9,6 +9,6 @@ namespace PackageManager.Services
 {
     public interface INuGetSearchTermTransformer
     {
-        string Transform(string searchTerm);
+        void Transform(NuGetSearchTerm searchTerm);
     }
 }

--- a/src/PackageManager.NuGet/Services/INuGetSearchTermTransformer.cs
+++ b/src/PackageManager.NuGet/Services/INuGetSearchTermTransformer.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PackageManager.Services
+{
+    public interface INuGetSearchTermTransformer
+    {
+        string Transform(string searchTerm);
+    }
+}

--- a/src/PackageManager.NuGet/Services/NuGetInstallService.cs
+++ b/src/PackageManager.NuGet/Services/NuGetInstallService.cs
@@ -182,7 +182,7 @@ namespace PackageManager.Services
                             {
                                 log.Debug($"Package '{package.PackageIdentity}' was found.");
 
-                                NuGetPackageFilterResult filterResult = packageFilter.IsPassed(metadata);
+                                NuGetPackageFilterResult filterResult = await packageFilter.IsPassedAsync(repository, metadata, cancellationToken);
                                 result.Add(new NuGetInstalledPackage(
                                     new NuGetPackage(metadata, repository, contentService, versionService),
                                     filterResult == NuGetPackageFilterResult.Ok

--- a/src/PackageManager.NuGet/Services/NuGetInstallService.cs
+++ b/src/PackageManager.NuGet/Services/NuGetInstallService.cs
@@ -63,7 +63,7 @@ namespace PackageManager.Services
             using (Stream fileContent = new FileStream(ConfigFilePath, FileMode.Open))
             {
                 PackagesConfigReader reader = new PackagesConfigReader(fileContent);
-                return reader.GetPackages().Any(p => p.PackageIdentity.Id == packageId);
+                return reader.GetPackages().Any(p => string.Equals(p.PackageIdentity.Id, packageId, StringComparison.CurrentCultureIgnoreCase));
             }
         }
 
@@ -77,7 +77,7 @@ namespace PackageManager.Services
             using (Stream fileContent = new FileStream(ConfigFilePath, FileMode.Open))
             {
                 PackagesConfigReader reader = new PackagesConfigReader(fileContent);
-                return reader.GetPackages().Any(p => p.PackageIdentity.Id == package.Id && p.PackageIdentity.Version.ToFullString() == package.Version);
+                return reader.GetPackages().Any(p => string.Equals(p.PackageIdentity.Id, package.Id, StringComparison.CurrentCultureIgnoreCase) && string.Equals(p.PackageIdentity.Version.ToFullString(), package.Version, StringComparison.CurrentCultureIgnoreCase));
             }
         }
 
@@ -118,7 +118,7 @@ namespace PackageManager.Services
             ReadPackageConfig(
                 (p, cache) => 
                 {
-                    if (p.PackageIdentity.Id == packageId)
+                    if (string.Equals(p.PackageIdentity.Id, packageId, StringComparison.CurrentCultureIgnoreCase))
                     {
                         version = p.PackageIdentity.Version;
                         framework = p.TargetFramework;
@@ -182,7 +182,7 @@ namespace PackageManager.Services
                             {
                                 log.Debug($"Package '{package.PackageIdentity}' was found.");
 
-                                NuGetPackageFilterResult filterResult = await packageFilter.IsPassedAsync(repository, metadata, cancellationToken);
+                                NuGetPackageFilterResult filterResult = await packageFilter.FilterAsync(repository, metadata, cancellationToken);
                                 result.Add(new NuGetInstalledPackage(
                                     new NuGetPackage(metadata, repository, contentService, versionService),
                                     filterResult == NuGetPackageFilterResult.Ok
@@ -209,7 +209,7 @@ namespace PackageManager.Services
             await ReadPackageConfig(
                 (package, context) =>
                 {
-                    if (package.PackageIdentity.Id == packageId)
+                    if (string.Equals(package.PackageIdentity.Id, packageId, StringComparison.CurrentCultureIgnoreCase))
                     {
                         result = new NuGetPackageIdentity(package.PackageIdentity);
                         return Task.FromResult(true);

--- a/src/PackageManager.NuGet/Services/NuGetPackageContentService.cs
+++ b/src/PackageManager.NuGet/Services/NuGetPackageContentService.cs
@@ -41,7 +41,7 @@ namespace PackageManager.Services
             using (var sourceCacheContext = new SourceCacheContext())
             {
                 var context = new PackageDownloadContext(sourceCacheContext, Path.GetTempPath(), true);
-                var result = await download.GetDownloadResourceResultAsync(package.Identity, context, String.Empty, nuGetLog, cancellationToken);
+                var result = await download.GetDownloadResourceResultAsync(package.Identity, context, string.Empty, nuGetLog, cancellationToken);
                 if (result.Status == DownloadResourceResultStatus.Cancelled)
                     throw new OperationCanceledException();
                 else if (result.Status == DownloadResourceResultStatus.NotFound)

--- a/src/PackageManager.NuGet/Services/NuGetPackageVersionService.cs
+++ b/src/PackageManager.NuGet/Services/NuGetPackageVersionService.cs
@@ -45,10 +45,10 @@ namespace PackageManager.Services
             try
             {
                 List<IPackage> result = new List<IPackage>();
-                if (await SearchOlderVersionsDirectly(result, resultCount, package, repository, versionFilter, cancellationToken))
+                if (await SearchOlderVersionsDirectlyAsync(result, resultCount, package, repository, versionFilter, cancellationToken))
                     return result;
 
-                if (await SearchOlderVersionsUsingMetadataResource(result, resultCount, package, repository, versionFilter, isPrereleaseIncluded, cancellationToken))
+                if (await SearchOlderVersionsUsingMetadataResourceAsync(result, resultCount, package, repository, versionFilter, isPrereleaseIncluded, cancellationToken))
                     return result;
 
                 return new List<IPackage>();
@@ -60,7 +60,7 @@ namespace PackageManager.Services
             }
         }
 
-        private async Task<bool> SearchOlderVersionsDirectly(List<IPackage> result, int resultCount, IPackageSearchMetadata package, SourceRepository repository, Func<IPackageSearchMetadata, IPackageSearchMetadata, bool> versionFilter, CancellationToken cancellationToken)
+        private async Task<bool> SearchOlderVersionsDirectlyAsync(List<IPackage> result, int resultCount, IPackageSearchMetadata package, SourceRepository repository, Func<IPackageSearchMetadata, IPackageSearchMetadata, bool> versionFilter, CancellationToken cancellationToken)
         {
             bool isSuccess = false;
             IEnumerable<VersionInfo> versions = null;
@@ -96,7 +96,7 @@ namespace PackageManager.Services
             return isSuccess;
         }
 
-        private async Task<bool> SearchOlderVersionsUsingMetadataResource(List<IPackage> result, int resultCount, IPackageSearchMetadata package, SourceRepository repository, Func<IPackageSearchMetadata, IPackageSearchMetadata, bool> versionFilter, bool isPrereleaseIncluded, CancellationToken cancellationToken)
+        private async Task<bool> SearchOlderVersionsUsingMetadataResourceAsync(List<IPackage> result, int resultCount, IPackageSearchMetadata package, SourceRepository repository, Func<IPackageSearchMetadata, IPackageSearchMetadata, bool> versionFilter, bool isPrereleaseIncluded, CancellationToken cancellationToken)
         {
             PackageMetadataResource metadataResource = await repository.GetResourceAsync<PackageMetadataResource>(cancellationToken);
             if (metadataResource == null)
@@ -136,7 +136,7 @@ namespace PackageManager.Services
         {
             log.Debug($"Found '{version.Identity}'.");
 
-            NuGetPackageFilterResult filterResult = await filter.IsPassedAsync(repository, version, cancellationToken);
+            NuGetPackageFilterResult filterResult = await filter.FilterAsync(repository, version, cancellationToken);
             switch (filterResult)
             {
                 case NuGetPackageFilterResult.Ok:

--- a/src/PackageManager.NuGet/Services/NuGetPackageVersionService.cs
+++ b/src/PackageManager.NuGet/Services/NuGetPackageVersionService.cs
@@ -45,7 +45,7 @@ namespace PackageManager.Services
             try
             {
                 List<IPackage> result = new List<IPackage>();
-                if (await SearchOlderVersionsDirectly(result, resultCount, package, repository, versionFilter))
+                if (await SearchOlderVersionsDirectly(result, resultCount, package, repository, versionFilter, cancellationToken))
                     return result;
 
                 if (await SearchOlderVersionsUsingMetadataResource(result, resultCount, package, repository, versionFilter, isPrereleaseIncluded, cancellationToken))
@@ -60,7 +60,7 @@ namespace PackageManager.Services
             }
         }
 
-        private async Task<bool> SearchOlderVersionsDirectly(List<IPackage> result, int resultCount, IPackageSearchMetadata package, SourceRepository repository, Func<IPackageSearchMetadata, IPackageSearchMetadata, bool> versionFilter)
+        private async Task<bool> SearchOlderVersionsDirectly(List<IPackage> result, int resultCount, IPackageSearchMetadata package, SourceRepository repository, Func<IPackageSearchMetadata, IPackageSearchMetadata, bool> versionFilter, CancellationToken cancellationToken)
         {
             bool isSuccess = false;
             IEnumerable<VersionInfo> versions = null;
@@ -81,7 +81,7 @@ namespace PackageManager.Services
                 // TODO: Filter prelease on V2 feed.
                 if (version.PackageSearchMetadata != null && versionFilter(package, version.PackageSearchMetadata))
                 {
-                    IPackage item = ProcessOlderVersion(repository, version.PackageSearchMetadata);
+                    IPackage item = await ProcessOlderVersionAsync(repository, version.PackageSearchMetadata, cancellationToken);
                     if (item != null)
                     {
                         result.Add(item);
@@ -118,7 +118,7 @@ namespace PackageManager.Services
                 {
                     if (versionFilter(package, version))
                     {
-                        IPackage item = ProcessOlderVersion(repository, version);
+                        IPackage item = await ProcessOlderVersionAsync(repository, version, cancellationToken);
                         if (item != null)
                         {
                             result.Add(item);
@@ -132,11 +132,11 @@ namespace PackageManager.Services
             return true;
         }
 
-        private IPackage ProcessOlderVersion(SourceRepository repository, IPackageSearchMetadata version)
+        private async Task<IPackage> ProcessOlderVersionAsync(SourceRepository repository, IPackageSearchMetadata version, CancellationToken cancellationToken)
         {
             log.Debug($"Found '{version.Identity}'.");
 
-            NuGetPackageFilterResult filterResult = filter.IsPassed(version);
+            NuGetPackageFilterResult filterResult = await filter.IsPassedAsync(repository, version, cancellationToken);
             switch (filterResult)
             {
                 case NuGetPackageFilterResult.Ok:

--- a/src/PackageManager.NuGet/Services/NuGetSearchService.cs
+++ b/src/PackageManager.NuGet/Services/NuGetSearchService.cs
@@ -198,7 +198,7 @@ namespace PackageManager.Services
 
         private async Task AddPackageAsync(List<IPackage> result, SourceRepository repository, IPackageSearchMetadata package, bool isPrereleaseIncluded, CancellationToken cancellationToken)
         {
-            NuGetPackageFilterResult filterResult = await filter.IsPassedAsync(repository, package, cancellationToken);
+            NuGetPackageFilterResult filterResult = await filter.FilterAsync(repository, package, cancellationToken);
             switch (filterResult)
             {
                 case NuGetPackageFilterResult.Ok:
@@ -234,7 +234,7 @@ namespace PackageManager.Services
 
             IEnumerable<IPackage> packages = await SearchAsync(packageSources, package.Id, new SearchOptions() { PageSize = 1, IsPrereleaseIncluded = isPrereleaseIncluded }, cancellationToken);
             IPackage latest = packages.FirstOrDefault();
-            if (latest != null && latest.Id == package.Id)
+            if (latest != null && string.Equals(latest.Id, package.Id, StringComparison.InvariantCultureIgnoreCase))
             {
                 log.Debug($"Found version '{latest.Version}'.");
                 return latest;

--- a/src/PackageManager.NuGet/Services/NuGetSearchService.cs
+++ b/src/PackageManager.NuGet/Services/NuGetSearchService.cs
@@ -102,7 +102,7 @@ namespace PackageManager.Services
                         if (result.Count >= options.PageSize)
                             break;
 
-                        await AddPackage(result, repository, package, options.IsPrereleaseIncluded, cancellationToken);
+                        await AddPackageAsync(result, repository, package, options.IsPrereleaseIncluded, cancellationToken);
                         sourceSearchPackageCount++;
                     }
 
@@ -128,9 +128,9 @@ namespace PackageManager.Services
             return result;
         }
 
-        private async Task AddPackage(List<IPackage> result, SourceRepository repository, IPackageSearchMetadata package, bool isPrereleaseIncluded, CancellationToken cancellationToken)
+        private async Task AddPackageAsync(List<IPackage> result, SourceRepository repository, IPackageSearchMetadata package, bool isPrereleaseIncluded, CancellationToken cancellationToken)
         {
-            NuGetPackageFilterResult filterResult = filter.IsPassed(package);
+            NuGetPackageFilterResult filterResult = await filter.IsPassedAsync(repository, package, cancellationToken);
             switch (filterResult)
             {
                 case NuGetPackageFilterResult.Ok:

--- a/src/PackageManager.NuGet/Services/NuGetSearchService.cs
+++ b/src/PackageManager.NuGet/Services/NuGetSearchService.cs
@@ -10,7 +10,6 @@ using Neptuo.Logging;
 using NuGet.Common;
 using NuGet.Protocol;
 using NuGet.Protocol.Core.Types;
-using NuGet.Versioning;
 using PackageManager.Logging;
 using PackageManager.Models;
 
@@ -61,29 +60,11 @@ namespace PackageManager.Services
             return options;
         }
 
-        private Task<IEnumerable<IPackageSearchMetadata>> SearchAsync(PackageSearchResource search, string searchText, SearchOptions options, CancellationToken cancellationToken)
-            => search.SearchAsync(searchText, new SearchFilter(options.IsPrereleaseIncluded), options.PageIndex * options.PageSize, options.PageSize, nuGetLog, cancellationToken);
-
         public async Task<IEnumerable<IPackage>> SearchAsync(IEnumerable<IPackageSource> packageSources, string searchText, SearchOptions options = default, CancellationToken cancellationToken = default)
         {
-            NuGetSearchTerm term = new NuGetSearchTerm();
-            term.Id.Add(searchText);
+            var (feedTerm, localTerm) = PrepareSearchTerms(searchText);
 
-            queryTransformer.Transform(term);
-            term.Id.Remove(searchText);
-
-            NuGetSearchTerm lateTerm = null;
-            if (term.IsEmpty())
-            {
-                term.Id.Add(searchText);
-            }
-            else
-            {
-                lateTerm = term.Clone();
-                lateTerm.Id.Add(searchText);
-            }
-
-            log.Debug($"Searching - user text:'{searchText}'; target query:'{term}'.");
+            log.Debug($"Searching - user text:'{searchText}'; feed query:'{feedTerm}'.");
 
             options = EnsureOptions(options);
 
@@ -96,7 +77,6 @@ namespace PackageManager.Services
             {
                 log.Debug($"Loading page '{options.PageIndex}'.");
 
-                bool hasItems = false;
                 foreach (IPackageSource packageSource in sources)
                 {
                     log.Debug($"Searching in '{packageSource.Uri}'.");
@@ -106,59 +86,14 @@ namespace PackageManager.Services
                     if (search == null)
                     {
                         log.Debug($"Source skipped, because it doesn't provide '{nameof(PackageSearchResource)}'.");
+
+                        sourcesToSkip.Add(packageSource);
                         continue;
                     }
 
-                    NuGetSearchTerm localTerm = null;
-                    bool clearLateTerm = false;
-                    if (search is LocalPackageSearchResource)
-                    {
-                        // Searching a feed from folder.
-                        localTerm = term;
-                        term = new NuGetSearchTerm();
-
-                        if (lateTerm == null)
-                        {
-                            lateTerm = localTerm;
-                            clearLateTerm = true;
-                        }
-                    }
-
-                    int sourceSearchPackageCount = 0;
-                    foreach (IPackageSearchMetadata package in await SearchAsync(search, term.ToString(), options, cancellationToken))
-                    {
-                        log.Debug($"Found '{package.Identity}'.");
-
-                        hasItems = true;
-                        if (result.Count >= options.PageSize)
-                            break;
-
-                        if (lateTerm != null && !lateTerm.IsMatched(package))
-                        {
-                            log.Debug($"Package skipped by late search term '{lateTerm}'.");
-                            continue;
-                        }
-
-                        await AddPackageAsync(result, repository, package, options.IsPrereleaseIncluded, cancellationToken);
-                        sourceSearchPackageCount++;
-                    }
-
-                    // If package source reached end, skip it from next probing.
-                    if (sourceSearchPackageCount < options.PageSize)
+                    if (!await ApplyLocalResourceSearchAsync(result, repository, search, feedTerm, localTerm, options, cancellationToken))
                         sourcesToSkip.Add(packageSource);
-
-                    if (localTerm != null)
-                    {
-                        term = localTerm;
-                        localTerm = null;
-
-                        if (clearLateTerm)
-                            lateTerm = null;
-                    }
                 }
-
-                if (!hasItems)
-                    break;
 
                 options = new SearchOptions()
                 {
@@ -168,11 +103,98 @@ namespace PackageManager.Services
 
                 foreach (IPackageSource source in sourcesToSkip)
                     sources.Remove(source);
+
+                if (sources.Count == 0)
+                    break;
             }
 
             log.Debug($"Search completed. Found '{result.Count}' items.");
             return result;
         }
+
+        /// <summary>
+        /// Prepares instance of terms for filtering in feed and in-app.
+        /// </summary>
+        /// <remarks>
+        /// localTerm should always have all search terms.
+        /// </remarks>
+        private (NuGetSearchTerm feedTerm, NuGetSearchTerm localTerm) PrepareSearchTerms(string searchText)
+        {
+            NuGetSearchTerm feedTerm = new NuGetSearchTerm();
+            feedTerm.Id.Add(searchText);
+
+            queryTransformer.Transform(feedTerm);
+            feedTerm.Id.Remove(searchText);
+
+            NuGetSearchTerm localTerm = null;
+            if (feedTerm.IsEmpty())
+            {
+                feedTerm.Id.Add(searchText);
+            }
+            else
+            {
+                localTerm = feedTerm.Clone();
+                localTerm.Id.Add(searchText);
+            }
+
+            return (feedTerm, localTerm);
+        }
+
+        /// <summary>
+        /// Tries to apply special conditions for looking in local folder feed.
+        /// </summary>
+        /// <returns><c>true</c> if search reached the end of the feed; <c>false</c> otherwise.</returns>
+        private Task<bool> ApplyLocalResourceSearchAsync(List<IPackage> result, SourceRepository repository, PackageSearchResource search, NuGetSearchTerm feedTerm, NuGetSearchTerm localTerm, SearchOptions options, CancellationToken cancellationToken)
+        {
+            if (search is LocalPackageSearchResource)
+            {
+                // Searching a feed from folder. Look for all packages and then filter in-app.
+                if (localTerm == null)
+                    localTerm = feedTerm;
+
+                feedTerm = new NuGetSearchTerm();
+            }
+
+            return ApplySearchAsync(result, repository, search, feedTerm, localTerm, options, cancellationToken);
+        }
+
+        /// <summary>
+        /// Execute search on <paramref name="search"/>.
+        /// </summary>
+        /// <returns><c>true</c> if search reached the end of the feed; <c>false</c> otherwise.</returns>
+        private async Task<bool> ApplySearchAsync(List<IPackage> result, SourceRepository repository, PackageSearchResource search, NuGetSearchTerm feedTerm, NuGetSearchTerm localTerm, SearchOptions options, CancellationToken cancellationToken)
+        {
+            if (localTerm != null && options.PageSize == 1)
+                options.PageSize = 10;
+
+            int sourceSearchPackageCount = 0;
+            foreach (IPackageSearchMetadata package in await SearchAsync(search, feedTerm.ToString(), options, cancellationToken))
+            {
+                sourceSearchPackageCount++;
+
+                log.Debug($"Found '{package.Identity}'.");
+
+                if (result.Count >= options.PageSize)
+                    break;
+
+                if (localTerm != null && !localTerm.IsMatched(package))
+                {
+                    log.Debug($"Package skipped by late search term '{localTerm}'.");
+                    continue;
+                }
+
+                await AddPackageAsync(result, repository, package, options.IsPrereleaseIncluded, cancellationToken);
+            }
+
+            // If package source reached end, skip it from next probing.
+            if (sourceSearchPackageCount < options.PageSize)
+                return false;
+
+            return true;
+        }
+
+        private Task<IEnumerable<IPackageSearchMetadata>> SearchAsync(PackageSearchResource search, string searchText, SearchOptions options, CancellationToken cancellationToken)
+            => search.SearchAsync(searchText, new SearchFilter(options.IsPrereleaseIncluded), options.PageIndex * options.PageSize, options.PageSize, nuGetLog, cancellationToken);
 
         private async Task AddPackageAsync(List<IPackage> result, SourceRepository repository, IPackageSearchMetadata package, bool isPrereleaseIncluded, CancellationToken cancellationToken)
         {

--- a/src/PackageManager.NuGet/Services/NuGetSearchTerm.cs
+++ b/src/PackageManager.NuGet/Services/NuGetSearchTerm.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using Neptuo;
+using NuGet.Protocol.Core.Types;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -7,7 +9,7 @@ using System.Threading.Tasks;
 
 namespace PackageManager.Services
 {
-    public class NuGetSearchTerm
+    public class NuGetSearchTerm : ICloneable<NuGetSearchTerm>
     {
         public List<string> Id { get; } = new List<string>();
         public List<string> Version { get; } = new List<string>();
@@ -54,6 +56,45 @@ namespace PackageManager.Services
                 return true;
 
             return false;
+        }
+
+        public bool IsMatched(IPackageSearchMetadata package)
+            => IsMatched(package.Identity.Id, Id)
+            && IsMatched(package.Identity.Version.OriginalVersion, Version)
+            && IsMatched(package.Title, Title)
+            && IsMatched(package.Tags, Tags)
+            && IsMatched(package.Description, Description)
+            && IsMatched(package.Summary, Summary)
+            && IsMatched(package.Owners, Owner);
+
+        private bool IsMatched(string packageValue, List<string> values)
+        {
+            bool result = true;
+            foreach (var value in values)
+            {
+                if (String.IsNullOrEmpty(value))
+                    continue;
+
+                if (packageValue.IndexOf(value, StringComparison.InvariantCultureIgnoreCase) != -1)
+                    return true;
+
+                result = false;
+            }
+
+            return result;
+        }
+
+        public NuGetSearchTerm Clone()
+        {
+            var clone = new NuGetSearchTerm();
+            clone.Id.AddRange(Id);
+            clone.Version.AddRange(Version);
+            clone.Title.AddRange(Title);
+            clone.Tags.AddRange(Tags);
+            clone.Description.AddRange(Description);
+            clone.Summary.AddRange(Summary);
+            clone.Owner.AddRange(Owner);
+            return clone;
         }
     }
 }

--- a/src/PackageManager.NuGet/Services/NuGetSearchTerm.cs
+++ b/src/PackageManager.NuGet/Services/NuGetSearchTerm.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PackageManager.Services
+{
+    public class NuGetSearchTerm
+    {
+        public List<string> Id { get; } = new List<string>();
+        public List<string> Version { get; } = new List<string>();
+        public List<string> Title { get; } = new List<string>();
+        public List<string> Tags { get; } = new List<string>();
+        public List<string> Description { get; } = new List<string>();
+        public List<string> Summary { get; } = new List<string>();
+        public List<string> Owner { get; } = new List<string>();
+
+        public override string ToString()
+        {
+            StringBuilder result = new StringBuilder();
+            Append(result, "id", Id);
+            Append(result, "version", Version);
+            Append(result, "title", Title);
+            Append(result, "tags", Tags);
+            Append(result, "description", Description);
+            Append(result, "summary", Summary);
+            Append(result, "owner", Owner);
+            return result.ToString();
+        }
+
+        private void Append(StringBuilder result, string key, List<string> values)
+        {
+            foreach (var value in values)
+                result.Append(" ").Append(key).Append(":").Append(value);
+        }
+
+        public bool IsEmpty()
+            => IsEmpty(Id) 
+            && IsEmpty(Version) 
+            && IsEmpty(Title) 
+            && IsEmpty(Tags) 
+            && IsEmpty(Description) 
+            && IsEmpty(Summary) 
+            && IsEmpty(Owner);
+
+        private bool IsEmpty(List<string> values)
+        {
+            if (values.Count == 0)
+                return false;
+
+            if (values.Any(s => !String.IsNullOrEmpty(s)))
+                return true;
+
+            return false;
+        }
+    }
+}

--- a/src/PackageManager.NuGet/Services/NuGetSearchTerm.cs
+++ b/src/PackageManager.NuGet/Services/NuGetSearchTerm.cs
@@ -52,7 +52,7 @@ namespace PackageManager.Services
             if (values.Count == 0)
                 return false;
 
-            if (values.Any(s => !String.IsNullOrEmpty(s)))
+            if (values.Any(s => !string.IsNullOrEmpty(s)))
                 return true;
 
             return false;
@@ -72,10 +72,10 @@ namespace PackageManager.Services
             bool result = true;
             foreach (var value in values)
             {
-                if (String.IsNullOrEmpty(value))
+                if (string.IsNullOrEmpty(value))
                     continue;
 
-                if (packageValue.IndexOf(value, StringComparison.InvariantCultureIgnoreCase) != -1)
+                if (packageValue.IndexOf(value, StringComparison.CurrentCultureIgnoreCase) != -1)
                     return true;
 
                 result = false;

--- a/src/PackageManager.NuGet/Services/OkNuGetPackageFilter.cs
+++ b/src/PackageManager.NuGet/Services/OkNuGetPackageFilter.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Protocol.Core.Types;
 
@@ -9,8 +10,8 @@ namespace PackageManager.Services
 {
     public class OkNuGetPackageFilter : INuGetPackageFilter
     {
-        public NuGetPackageFilterResult IsPassed(IPackageSearchMetadata package)
-            => NuGetPackageFilterResult.Ok;
+        public Task<NuGetPackageFilterResult> IsPassedAsync(SourceRepository repository, IPackageSearchMetadata package, CancellationToken cancellationToken)
+            => Task.FromResult(NuGetPackageFilterResult.Ok);
 
         #region Singleton
 

--- a/src/PackageManager.NuGet/Services/OkNuGetPackageFilter.cs
+++ b/src/PackageManager.NuGet/Services/OkNuGetPackageFilter.cs
@@ -10,31 +10,9 @@ namespace PackageManager.Services
 {
     public class OkNuGetPackageFilter : INuGetPackageFilter
     {
-        public Task<NuGetPackageFilterResult> IsPassedAsync(SourceRepository repository, IPackageSearchMetadata package, CancellationToken cancellationToken)
+        public Task<NuGetPackageFilterResult> FilterAsync(SourceRepository repository, IPackageSearchMetadata package, CancellationToken cancellationToken)
             => Task.FromResult(NuGetPackageFilterResult.Ok);
 
-        #region Singleton
-
-        private static OkNuGetPackageFilter instance;
-        private static object instanceLock = new object();
-
-        public static OkNuGetPackageFilter Instance
-        {
-            get
-            {
-                if (instance == null)
-                {
-                    lock (instanceLock)
-                    {
-                        if (instance == null)
-                            instance = new OkNuGetPackageFilter();
-                    }
-                }
-
-                return instance;
-            }
-        }
-
-        #endregion
+        public readonly static OkNuGetPackageFilter Instance = new OkNuGetPackageFilter();
     }
 }

--- a/src/PackageManager.UI/App.xaml.cs
+++ b/src/PackageManager.UI/App.xaml.cs
@@ -69,7 +69,7 @@ namespace PackageManager
             NuGetSourceRepositoryFactory repositoryFactory = new NuGetSourceRepositoryFactory();
             INuGetPackageFilter packageFilter = null;
             if (Args.Dependencies.Any())
-                packageFilter = new DependencyNuGetPackageFilter(Args.Dependencies, frameworks);
+                packageFilter = new DependencyNuGetPackageFilter(LogFactory.Scope("Filter"), Args.Dependencies, frameworks);
 
             NuGetPackageContent.IFrameworkFilter frameworkFilter = null;
             if (Args.Monikers.Any())

--- a/src/PackageManager.UI/App.xaml.cs
+++ b/src/PackageManager.UI/App.xaml.cs
@@ -75,13 +75,17 @@ namespace PackageManager
             if (Args.Monikers.Any())
                 frameworkFilter = new NuGetFrameworkFilter(frameworks);
 
+            INuGetSearchTermTransformer termTransformer = null;
+            if (Args.Tags != null)
+                termTransformer = new TagsNuGetSearchTermTransformer(Args.Tags);
+
             var selfPackageConfiguration = new SelfPackageConfiguration(Args.SelfPackageId);
 
             SelfPackageConverter.Configuration = selfPackageConfiguration;
 
             var contentService = new NuGetPackageContentService(log, frameworkFilter);
             var versionService = new NuGetPackageVersionService(contentService, log, packageFilter, frameworkFilter);
-            var searchService = new NuGetSearchService(repositoryFactory, LogFactory.Scope("Search"), contentService, versionService, packageFilter, frameworkFilter);
+            var searchService = new NuGetSearchService(repositoryFactory, LogFactory.Scope("Search"), contentService, versionService, packageFilter, termTransformer);
             var installService = new NuGetInstallService(repositoryFactory, LogFactory.Scope("Install"), Args.Path, contentService, versionService, packageFilter, frameworkFilter);
             var selfUpdateService = new SelfUpdateService(this, ProcessService);
 

--- a/src/PackageManager.UI/App.xaml.cs
+++ b/src/PackageManager.UI/App.xaml.cs
@@ -45,7 +45,7 @@ namespace PackageManager
                 .AddSerializer(MemoryLogSerializer);
 
             ILog log = LogFactory.Scope("Startup");
-            log.Debug($"Startup arguments: {Environment.NewLine}{String.Join(" ", e.Args)}");
+            log.Debug($"Startup arguments: {Environment.NewLine}{string.Join(" ", e.Args)}");
             log.Debug($"Current version: {VersionInfo.Version}");
 
             Args = new Args(e.Args);
@@ -174,10 +174,10 @@ namespace PackageManager
             updates.Refresh.Completed += async () =>
             {
                 bool canUpdate = false;
-                PackageUpdateViewModel package = updates.Packages.FirstOrDefault(p => p.Current.Id == Args.SelfPackageId);
+                PackageUpdateViewModel package = updates.Packages.FirstOrDefault(p => string.Equals(p.Current.Id, Args.SelfPackageId, StringComparison.CurrentCultureIgnoreCase));
                 if (package != null)
                 {
-                    if (package.Target.Version == Args.SelfUpdateVersion)
+                    if (string.Equals(package.Target.Version, Args.SelfUpdateVersion, StringComparison.CurrentCultureIgnoreCase))
                     {
                         canUpdate = true;
                     }
@@ -186,7 +186,7 @@ namespace PackageManager
                         if (package.Current.LoadVersions.CanExecute())
                             package.Current.LoadVersions.Execute();
 
-                        PackageViewModel version = package.Current.Versions.FirstOrDefault(p => p.Version == Args.SelfUpdateVersion);
+                        PackageViewModel version = package.Current.Versions.FirstOrDefault(p => string.Equals(p.Version, Args.SelfUpdateVersion, StringComparison.CurrentCultureIgnoreCase));
                         if (version != null)
                         {
                             package.Target = version.Model;

--- a/src/PackageManager.UI/Args.cs
+++ b/src/PackageManager.UI/Args.cs
@@ -17,6 +17,7 @@ namespace PackageManager
         public bool IsSelfUpdate { get; set; }
         public string SelfOriginalPath { get; set; }
         public string SelfUpdateVersion { get; set; }
+        public string Tags { get; set; }
 
         public IReadOnlyCollection<string> ProcessNamesToKillBeforeChange { get; set; }
 
@@ -74,6 +75,9 @@ namespace PackageManager
                 case "--dependencies":
                     Dependencies = ParseDependencies(value);
                     return true;
+                case "--tags":
+                    Tags = value;
+                    return true;
                 case "--selfpackageid":
                     SelfPackageId = value;
                     return true;
@@ -130,6 +134,9 @@ namespace PackageManager
                 result.Append(" --dependencies ");
                 result.Append(String.Join(",", Dependencies.Select(d => d.Id + (d.Version != null ? "-v" + d.Version : ""))));
             }
+
+            if (!String.IsNullOrEmpty(Tags))
+                result.Append($" --tags {Tags}");
 
             if (!String.IsNullOrEmpty(SelfPackageId))
                 result.Append($" --selfpackageid {SelfPackageId}");

--- a/src/PackageManager.UI/Args.cs
+++ b/src/PackageManager.UI/Args.cs
@@ -120,38 +120,38 @@ namespace PackageManager
         {
             StringBuilder result = new StringBuilder();
 
-            if (!String.IsNullOrEmpty(Path))
+            if (!string.IsNullOrEmpty(Path))
                 result.Append($"--path \"{Path}\"");
 
             if (Monikers.Count > 0)
             {
                 result.Append($" --monikers ");
-                result.Append(String.Join(",", Monikers));
+                result.Append(string.Join(",", Monikers));
             }
 
             if (Dependencies.Count > 0)
             {
                 result.Append(" --dependencies ");
-                result.Append(String.Join(",", Dependencies.Select(d => d.Id + (d.Version != null ? "-v" + d.Version : ""))));
+                result.Append(string.Join(",", Dependencies.Select(d => d.Id + (d.Version != null ? "-v" + d.Version : ""))));
             }
 
-            if (!String.IsNullOrEmpty(Tags))
+            if (!string.IsNullOrEmpty(Tags))
                 result.Append($" --tags {Tags}");
 
-            if (!String.IsNullOrEmpty(SelfPackageId))
+            if (!string.IsNullOrEmpty(SelfPackageId))
                 result.Append($" --selfpackageid {SelfPackageId}");
 
             if (IsSelfUpdate)
                 result.Append(" --selfupdate");
 
-            if (!String.IsNullOrEmpty(SelfOriginalPath))
+            if (!string.IsNullOrEmpty(SelfOriginalPath))
                 result.Append($" --selforiginalpath \"{SelfOriginalPath}\"");
 
-            if (!String.IsNullOrEmpty(SelfUpdateVersion))
+            if (!string.IsNullOrEmpty(SelfUpdateVersion))
                 result.Append($" --selfupdateversion \"{SelfUpdateVersion}\"");
 
             if (ProcessNamesToKillBeforeChange != null && ProcessNamesToKillBeforeChange.Count > 0)
-                result.Append($" --processnamestokillbeforechange \"{String.Join(",", ProcessNamesToKillBeforeChange)}\"");
+                result.Append($" --processnamestokillbeforechange \"{string.Join(",", ProcessNamesToKillBeforeChange)}\"");
 
             return result.ToString();
         }

--- a/src/PackageManager.UI/Models/SelfPackage.cs
+++ b/src/PackageManager.UI/Models/SelfPackage.cs
@@ -29,7 +29,7 @@ namespace PackageManager.Models
             if (other == null)
                 return false;
 
-            return Id == other.Id && Version == other.Version;
+            return string.Equals(Id, other.Id, StringComparison.CurrentCultureIgnoreCase) && string.Equals(Version, other.Version, StringComparison.CurrentCultureIgnoreCase);
         }
     }
 }

--- a/src/PackageManager.UI/Services/DependencyNuGetPackageFilter.cs
+++ b/src/PackageManager.UI/Services/DependencyNuGetPackageFilter.cs
@@ -2,54 +2,75 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Neptuo;
+using Neptuo.Logging;
+using NuGet.Common;
 using NuGet.Frameworks;
 using NuGet.Packaging.Core;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
+using PackageManager.Logging;
 
 namespace PackageManager.Services
 {
     public class DependencyNuGetPackageFilter : INuGetPackageFilter
     {
+        private readonly ILog log;
+        private readonly NuGetLogger nuGetLogger;
         private readonly IReadOnlyCollection<Args.Dependency> dependencies;
         private readonly IReadOnlyCollection<NuGetFramework> frameworks;
 
-        public DependencyNuGetPackageFilter(IReadOnlyCollection<Args.Dependency> dependencies, IReadOnlyCollection<NuGetFramework> frameworks)
+        public DependencyNuGetPackageFilter(ILog log, IReadOnlyCollection<Args.Dependency> dependencies, IReadOnlyCollection<NuGetFramework> frameworks)
         {
+            Ensure.NotNull(log, "log");
             Ensure.NotNull(dependencies, "dependencies");
             Ensure.NotNull(frameworks, "frameworks");
+            this.log = log;
             this.dependencies = dependencies;
             this.frameworks = frameworks;
+
+            nuGetLogger = new NuGetLogger(log);
         }
 
-        public NuGetPackageFilterResult IsPassed(IPackageSearchMetadata package)
+        public async Task<NuGetPackageFilterResult> IsPassedAsync(SourceRepository repository, IPackageSearchMetadata package, CancellationToken cancellationToken)
         {
             if (!dependencies.Any())
                 return NuGetPackageFilterResult.Ok;
 
-            foreach (var group in package.DependencySets)
-            {
-                if (frameworks.Contains(group.TargetFramework))
-                {
-                    NuGetPackageFilterResult result = NuGetPackageFilterResult.Ok;
+            DependencyInfoResource resource = await repository.GetResourceAsync<DependencyInfoResource>();
+            if (resource == null)
+                return NuGetPackageFilterResult.NotCompatible;
 
+            NuGetPackageFilterResult result = NuGetPackageFilterResult.Ok;
+            foreach (NuGetFramework framework in frameworks)
+            {
+                SourcePackageDependencyInfo dependencyInfo = await resource.ResolvePackage(package.Identity, framework, new SourceCacheContext(), nuGetLogger, cancellationToken);
+                if (dependencyInfo != null)
+                {
                     // Dependency filtering:
                     // - When incompatible dependency version is found there is a chance that previous version has the right one.
                     // - When all dependencies are missing, don't even try previous versions.
                     foreach (var dependency in dependencies)
                     {
-                        PackageDependency packageDependency = group.Packages.FirstOrDefault(p => p.Id == dependency.Id);
+                        PackageDependency packageDependency = dependencyInfo.Dependencies.FirstOrDefault(p => p.Id == dependency.Id);
                         if (packageDependency == null)
+                        {
+                            log.Info($"Package '{package.Identity}' skipped: missing dependency '{dependency.Id}'.");
                             result = NuGetPackageFilterResult.NotCompatible;
+                        }
 
                         if (dependency.Version != null && !packageDependency.VersionRange.Satisfies(new NuGetVersion(dependency.Version)))
+                        {
+                            log.Info($"Package '{package.Identity}' skipped: not compatible version '{dependency.Version}' on dependency '{dependency.Id}'.");
                             return NuGetPackageFilterResult.NotCompatibleVersion;
+                        }
                     }
 
                     return result;
                 }
+
             }
 
             return NuGetPackageFilterResult.NotCompatible;

--- a/src/PackageManager.UI/Services/DependencyNuGetPackageFilter.cs
+++ b/src/PackageManager.UI/Services/DependencyNuGetPackageFilter.cs
@@ -34,7 +34,7 @@ namespace PackageManager.Services
             nuGetLogger = new NuGetLogger(log);
         }
 
-        public async Task<NuGetPackageFilterResult> IsPassedAsync(SourceRepository repository, IPackageSearchMetadata package, CancellationToken cancellationToken)
+        public async Task<NuGetPackageFilterResult> FilterAsync(SourceRepository repository, IPackageSearchMetadata package, CancellationToken cancellationToken)
         {
             if (!dependencies.Any())
                 return NuGetPackageFilterResult.Ok;
@@ -54,7 +54,7 @@ namespace PackageManager.Services
                     // - When all dependencies are missing, don't even try previous versions.
                     foreach (var dependency in dependencies)
                     {
-                        PackageDependency packageDependency = dependencyInfo.Dependencies.FirstOrDefault(p => p.Id == dependency.Id);
+                        PackageDependency packageDependency = dependencyInfo.Dependencies.FirstOrDefault(p => string.Equals(p.Id, dependency.Id, StringComparison.CurrentCultureIgnoreCase));
                         if (packageDependency == null)
                         {
                             log.Info($"Package '{package.Identity}' skipped: missing dependency '{dependency.Id}'.");

--- a/src/PackageManager.UI/Services/TagsNuGetSearchTermTransformer.cs
+++ b/src/PackageManager.UI/Services/TagsNuGetSearchTermTransformer.cs
@@ -1,0 +1,29 @@
+﻿using Neptuo;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PackageManager.Services
+{
+    public class TagsNuGetSearchTermTransformer : INuGetSearchTermTransformer
+    {
+        private readonly string tags;
+
+        public TagsNuGetSearchTermTransformer(string tags)
+        {
+            Ensure.NotNull(tags, "tags");
+            this.tags = tags;
+        }
+
+        public string Transform(string searchTerm)
+        {
+            if (String.IsNullOrEmpty(tags))
+                return searchTerm;
+
+            return $"{searchTerm} tags:{tags}";
+        }
+    }
+}

--- a/src/PackageManager.UI/Services/TagsNuGetSearchTermTransformer.cs
+++ b/src/PackageManager.UI/Services/TagsNuGetSearchTermTransformer.cs
@@ -18,12 +18,10 @@ namespace PackageManager.Services
             this.tags = tags;
         }
 
-        public string Transform(string searchTerm)
+        public void Transform(NuGetSearchTerm searchTerm)
         {
-            if (String.IsNullOrEmpty(tags))
-                return searchTerm;
-
-            return $"{searchTerm} tags:{tags}";
+            if (!String.IsNullOrEmpty(tags))
+                searchTerm.Tags.Add(tags);
         }
     }
 }

--- a/src/PackageManager.UI/Services/TagsNuGetSearchTermTransformer.cs
+++ b/src/PackageManager.UI/Services/TagsNuGetSearchTermTransformer.cs
@@ -20,7 +20,7 @@ namespace PackageManager.Services
 
         public void Transform(NuGetSearchTerm searchTerm)
         {
-            if (!String.IsNullOrEmpty(tags))
+            if (!string.IsNullOrEmpty(tags))
                 searchTerm.Tags.Add(tags);
         }
     }

--- a/src/PackageManager.UI/Views/Converters/DropNewLineConverter.cs
+++ b/src/PackageManager.UI/Views/Converters/DropNewLineConverter.cs
@@ -13,11 +13,11 @@ namespace PackageManager.Views.Converters
         public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
         {
             string target = value?.ToString();
-            if (String.IsNullOrEmpty(target))
+            if (string.IsNullOrEmpty(target))
                 return target;
 
-            target = target.Replace(Environment.NewLine, String.Empty);
-            target = target.Replace("\n", String.Empty);
+            target = target.Replace(Environment.NewLine, string.Empty);
+            target = target.Replace("\n", string.Empty);
             return target;
         }
 

--- a/src/PackageManager.UI/Views/Converters/NullConverter.cs
+++ b/src/PackageManager.UI/Views/Converters/NullConverter.cs
@@ -21,7 +21,7 @@ namespace PackageManager.Views.Converters
             if (value is string)
             {
                 string stringValue = value as string;
-                if (stringValue == String.Empty)
+                if (stringValue == string.Empty)
                     return TrueValue;
             }
 

--- a/src/PackageManager.UI/Views/DesignData/MockInstallService.cs
+++ b/src/PackageManager.UI/Views/DesignData/MockInstallService.cs
@@ -18,7 +18,7 @@ namespace PackageManager.Views.DesignData
             => false;
 
         public bool IsInstalled(IPackageIdentity package)
-            => Installed?.Id == package?.Id && Installed?.Version == package?.Version;
+            => string.Equals(Installed?.Id, package?.Id, StringComparison.CurrentCultureIgnoreCase) && string.Equals(Installed?.Version, package?.Version, StringComparison.CurrentCultureIgnoreCase);
 
         public void Install(IPackageIdentity package)
         { }

--- a/src/PackageManager.UI/Views/DesignData/MockPackage.cs
+++ b/src/PackageManager.UI/Views/DesignData/MockPackage.cs
@@ -27,7 +27,7 @@ namespace PackageManager.Views.DesignData
             if (other == null)
                 return false;
 
-            return Id == other.Id && Version == other.Version;
+            return string.Equals(Id, other.Id, StringComparison.CurrentCultureIgnoreCase) && string.Equals(Version, other.Version, StringComparison.CurrentCultureIgnoreCase);
         }
 
         public bool Equals(IPackage other)

--- a/src/PackageManager.UI/Views/LogWindow.xaml.cs
+++ b/src/PackageManager.UI/Views/LogWindow.xaml.cs
@@ -32,7 +32,7 @@ namespace PackageManager.Views
         private async void RefreshContent()
         {
             TextContent.Text = log.GetContent();
-            if (String.IsNullOrEmpty(TextContent.Text))
+            if (string.IsNullOrEmpty(TextContent.Text))
                 TextContent.Text = "No entries.";
 
             await Task.Delay(50);

--- a/src/PackageManager/ViewModels/Commands/SaveSourceCommand.cs
+++ b/src/PackageManager/ViewModels/Commands/SaveSourceCommand.cs
@@ -64,7 +64,7 @@ namespace PackageManager.ViewModels.Commands
             if (string.IsNullOrEmpty(Name))
                 return false;
 
-            if (sources.Any(s => s.Name == Name && !(edit == null || edit == s)))
+            if (sources.Any(s => string.Equals(s.Name, Name, StringComparison.CurrentCultureIgnoreCase) && !(edit == null || edit == s)))
                 return false;
 
             if (string.IsNullOrEmpty(Url))

--- a/src/PackageManager/ViewModels/PackageSourceSelectorViewModel.cs
+++ b/src/PackageManager/ViewModels/PackageSourceSelectorViewModel.cs
@@ -23,10 +23,10 @@ namespace PackageManager.ViewModels
             {
                 if (selectedSources == null)
                 {
-                    if (string.IsNullOrEmpty(SelectedName) || SelectedName == AllFeedName)
+                    if (string.IsNullOrEmpty(SelectedName) || string.Equals(SelectedName, AllFeedName, StringComparison.CurrentCultureIgnoreCase))
                         selectedSources = service.All;
                     else
-                        selectedSources = new List<IPackageSource>(1) { service.All.First(s => s.Name == SelectedName) };
+                        selectedSources = new List<IPackageSource>(1) { service.All.First(s => string.Equals(s.Name, SelectedName, StringComparison.CurrentCultureIgnoreCase)) };
                 }
 
                 return selectedSources;
@@ -53,7 +53,7 @@ namespace PackageManager.ViewModels
                         if (value == null)
                             service.MarkAsPrimary(null);
                         else
-                            service.MarkAsPrimary(service.All.FirstOrDefault(s => s.Name == value));
+                            service.MarkAsPrimary(service.All.FirstOrDefault(s => string.Equals(s.Name, value, StringComparison.CurrentCultureIgnoreCase)));
                     }
                 }
             }
@@ -96,7 +96,7 @@ namespace PackageManager.ViewModels
                 if (isSelectedNameContained)
                     SelectedName = selectedName;
                 else if (service.Primary != null)
-                    SelectedName = SourceNames.FirstOrDefault(s => s == service.Primary.Name);
+                    SelectedName = SourceNames.FirstOrDefault(s => string.Equals(s, service.Primary.Name, StringComparison.CurrentCultureIgnoreCase));
                 else
                     SelectedName = SourceNames.FirstOrDefault();
             }

--- a/src/PackageManager/ViewModels/PackageSourceSelectorViewModel.cs
+++ b/src/PackageManager/ViewModels/PackageSourceSelectorViewModel.cs
@@ -48,10 +48,13 @@ namespace PackageManager.ViewModels
 
                     selectedSources = null;
 
-                    if (value == null)
-                        service.MarkAsPrimary(null);
-                    else
-                        service.MarkAsPrimary(service.All.FirstOrDefault(s => s.Name == value));
+                    if (!isServiceUpdating)
+                    {
+                        if (value == null)
+                            service.MarkAsPrimary(null);
+                        else
+                            service.MarkAsPrimary(service.All.FirstOrDefault(s => s.Name == value));
+                    }
                 }
             }
         }
@@ -68,31 +71,42 @@ namespace PackageManager.ViewModels
 
         private void OnServiceChanged()
         {
-            string selectedName = SelectedName;
-            SourceNames.Clear();
-
-            bool isSelectedNameContained = false;
-            void Add(string name)
+            try
             {
-                if (!isSelectedNameContained)
-                    isSelectedNameContained = name == selectedName;
+                isServiceUpdating = true;
 
-                SourceNames.Add(name);
+                string selectedName = SelectedName;
+                SourceNames.Clear();
+
+                bool isSelectedNameContained = false;
+                void Add(string name)
+                {
+                    if (!isSelectedNameContained)
+                        isSelectedNameContained = name == selectedName;
+
+                    SourceNames.Add(name);
+                }
+
+                if (service.All.Count > 1)
+                    Add(AllFeedName);
+
+                foreach (IPackageSource source in service.All)
+                    Add(source.Name);
+
+                if (isSelectedNameContained)
+                    SelectedName = selectedName;
+                else if (service.Primary != null)
+                    SelectedName = SourceNames.FirstOrDefault(s => s == service.Primary.Name);
+                else
+                    SelectedName = SourceNames.FirstOrDefault();
             }
-
-            if (service.All.Count > 1)
-                Add(AllFeedName);
-
-            foreach (IPackageSource source in service.All)
-                Add(source.Name);
-
-            if (isSelectedNameContained)
-                SelectedName = selectedName;
-            else if(service.Primary != null)
-                SelectedName = SourceNames.FirstOrDefault(s => s == service.Primary.Name);
-            else
-                SelectedName = SourceNames.FirstOrDefault();
+            finally
+            {
+                isServiceUpdating = false;
+            }
         }
+
+        private bool isServiceUpdating = false;
 
         public void Dispose()
         {

--- a/src/PackageManager/ViewModels/PackageViewModel.cs
+++ b/src/PackageManager/ViewModels/PackageViewModel.cs
@@ -77,7 +77,7 @@ namespace PackageManager.ViewModels
             if (other == null)
                 return false;
 
-            return Id == other.Id && Version == other.Version;
+            return string.Equals(Id, other.Id, StringComparison.CurrentCultureIgnoreCase) && string.Equals(Version, other.Version, StringComparison.CurrentCultureIgnoreCase);
         }
 
         public override int GetHashCode()

--- a/test/PackageManager.NuGet.Tests/Services/InstallService.cs
+++ b/test/PackageManager.NuGet.Tests/Services/InstallService.cs
@@ -28,6 +28,7 @@ namespace PackageManager.Services
 
             var frameworkFilter = new NuGetFrameworkFilter(frameworks);
             var packageFilter = new DependencyNuGetPackageFilter(
+                new DefaultLog(),
                 new List<Args.Dependency>()
                 {
                     new Args.Dependency("GitExtensions.Extensibility", null)

--- a/test/PackageManager.NuGet.Tests/Services/SearchService.cs
+++ b/test/PackageManager.NuGet.Tests/Services/SearchService.cs
@@ -28,6 +28,7 @@ namespace PackageManager.Services
 
             var frameworkFilter = new NuGetFrameworkFilter(frameworks);
             var packageFilter = new DependencyNuGetPackageFilter(
+                new DefaultLog(),
                 new List<Args.Dependency>()
                 {
                     new Args.Dependency("GitExtensions.Extensibility", null)
@@ -45,10 +46,10 @@ namespace PackageManager.Services
                     frameworkFilter
                 ),
                 new DependencyNuGetPackageFilter(
+                    new DefaultLog(),
                     new List<Args.Dependency>() { new Args.Dependency("GitExtensions.Extensibility", null) },
                     frameworks
-                ),
-                new NuGetFrameworkFilter(frameworks)
+                )
             );
 
             EnsureConfigDeleted(configFilePath);

--- a/test/PackageManager.NuGet.Tests/Services/TestInstallService.cs
+++ b/test/PackageManager.NuGet.Tests/Services/TestInstallService.cs
@@ -56,7 +56,7 @@ namespace PackageManager.Services
 
             Reader(reader =>
             {
-                Assert.IsTrue(reader.GetPackages().Any(p => p.PackageIdentity.Id == package.Object.Id && p.PackageIdentity.Version.ToFullString() == package.Object.Version));
+                Assert.IsTrue(reader.GetPackages().Any(p => string.Equals(p.PackageIdentity.Id, package.Object.Id, StringComparison.CurrentCultureIgnoreCase) && string.Equals(p.PackageIdentity.Version.ToFullString(), package.Object.Version, StringComparison.CurrentCultureIgnoreCase)));
             });
         }
 
@@ -69,7 +69,7 @@ namespace PackageManager.Services
 
             Reader(reader =>
             {
-                Assert.IsFalse(reader.GetPackages().Any(p => p.PackageIdentity.Id == package.Object.Id && p.PackageIdentity.Version.ToFullString() == package.Object.Version));
+                Assert.IsFalse(reader.GetPackages().Any(p => string.Equals(p.PackageIdentity.Id, package.Object.Id, StringComparison.CurrentCultureIgnoreCase) && string.Equals(p.PackageIdentity.Version.ToFullString(), package.Object.Version, StringComparison.CurrentCultureIgnoreCase)));
             });
         }
 


### PR DESCRIPTION
Resolves #27.

All searching is now in form of `id: {searchTerm} tags:GitExtensions`. This pre-filters packages marked as GitExtensions, than it loads a dependency graph (one query per package) and checks if dependency on `GitExtensions.Extensibility` exists.

Searching using nuget.org search syntax (https://docs.microsoft.com/en-us/nuget/consume-packages/finding-and-choosing-packages#search-syntax) is not ideal.

**When search term is "g", it won't find "GitExtensions.SVN"; the user must type "git", or "extensions".**
This behavior can be even seen on the web:
- https://www.nuget.org/packages?q=id%3Agitextension (0 packages)
- https://www.nuget.org/packages?q=id%3Agitextensions (6 packages)

**It seems it doesn't work well on MyGet.**
- In blog post from [2013 they said it should work](https://blog.myget.org/post/2013/03/27/improved-search-syntax-in-nuget-client-and-on-your-myget-feeds.html), but from my observation it just ignores the "id part".
- Using "id:{searchTerm}" requires to match whole packageId, nothing like "starts with" or "contains".

**It doesn't work at all when source is a folder on disk.**
- Using "id:{searchTerm}" requires to match whole packageId, nothing like "starts with" or "contains".
- Tags searching doesn't work.

### Solution
- On all feeds except local folder, load packages with tags filter, then apply id filter on loaded packages.
- On local folder feed, load all packages from feed, then apply tags and id filters on loaded packages.
- All local (in-app) filters are applied as invariant-culture ignore-case.