### PR TITLE
place all plugins in sub-directories

### DIFF
--- a/src/GitExtensions.PluginManager/GitExtensions.PluginManager.csproj
+++ b/src/GitExtensions.PluginManager/GitExtensions.PluginManager.csproj
@@ -13,7 +13,7 @@
   <PropertyGroup>
     <PackageManagerTargetPath>PackageManager\PackageManager.UI.exe</PackageManagerTargetPath>
     <PackageManagerSourcePath>..\PackageManager.UI\bin\$(Configuration)\$(TargetFramework)\PackageManager.UI.exe</PackageManagerSourcePath>
-    <GitExtensionsDebugPluginsPath>..\..\references\GitExtensions\UserPlugins\</GitExtensionsDebugPluginsPath>
+    <GitExtensionsDebugPluginsPath>..\..\references\GitExtensions\UserPlugins\GitExtensions.PluginManager\</GitExtensionsDebugPluginsPath>
     <GitExtensionsReferenceSource>appveyor</GitExtensionsReferenceSource>
     <GitExtensionsReferenceVersion>v3.2.0.5938</GitExtensionsReferenceVersion>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/src/GitExtensions.PluginManager/Plugin.cs
+++ b/src/GitExtensions.PluginManager/Plugin.cs
@@ -58,7 +58,7 @@ namespace GitExtensions.PluginManager
 
             ProcessStartInfo info = new ProcessStartInfo()
             {
-                FileName = Path.Combine(pluginsPath, PluginManagerRelativePath),
+                FileName = Path.Combine(pluginsPath, PackageId, PluginManagerRelativePath),
                 Arguments = args.ToString(),
                 UseShellExecute = false,
             };

--- a/src/PackageManager.UI/Exceptions/PackageInstallExceptionHandler.cs
+++ b/src/PackageManager.UI/Exceptions/PackageInstallExceptionHandler.cs
@@ -30,7 +30,7 @@ namespace PackageManager.Exceptions
 
         void IExceptionHandler<IExceptionHandlerContext<PackageFileRemovalException>>.Handle(IExceptionHandlerContext<PackageFileRemovalException> context)
         {
-            navigator.Notify("Package Removal Error", $"Error deleting file to '{context.Exception.FilePath}'", Navigator.MessageType.Error);
+            navigator.Notify("Package Removal Error", $"Error deleting file '{context.Exception.FilePath}'", Navigator.MessageType.Error);
             context.IsHandled = true;
         }
     }

--- a/src/PackageManager/ViewModels/Commands/InstallCommand.cs
+++ b/src/PackageManager/ViewModels/Commands/InstallCommand.cs
@@ -4,6 +4,7 @@ using PackageManager.Models;
 using PackageManager.Services;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -37,7 +38,9 @@ namespace PackageManager.ViewModels.Commands
             if (execute)
             {
                 IPackageContent packageContent = await package.GetContentAsync(cancellationToken);
-                await packageContent.ExtractToAsync(service.Path, cancellationToken);
+                string pluginPath = Path.Combine(service.Path, package.Id);
+                Directory.CreateDirectory(pluginPath);
+                await packageContent.ExtractToAsync(pluginPath, cancellationToken);
 
                 service.Install(package);
             }

--- a/src/PackageManager/ViewModels/Commands/ReinstallCommand.cs
+++ b/src/PackageManager/ViewModels/Commands/ReinstallCommand.cs
@@ -4,6 +4,7 @@ using PackageManager.Models;
 using PackageManager.Services;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -30,8 +31,9 @@ namespace PackageManager.ViewModels.Commands
         protected override async Task ExecuteAsync(IPackage package, CancellationToken cancellationToken)
         {
             IPackageContent packageContent = await package.GetContentAsync(cancellationToken);
-            await packageContent.RemoveFromAsync(service.Path, cancellationToken);
-            await packageContent.ExtractToAsync(service.Path, cancellationToken);
+            string pluginPath = Path.Combine(service.Path, package.Id);
+            await packageContent.RemoveFromAsync(pluginPath, cancellationToken);
+            await packageContent.ExtractToAsync(pluginPath, cancellationToken);
         }
 
         public new void RaiseCanExecuteChanged()

--- a/src/PackageManager/ViewModels/Commands/UninstallCommand.cs
+++ b/src/PackageManager/ViewModels/Commands/UninstallCommand.cs
@@ -4,6 +4,7 @@ using PackageManager.Models;
 using PackageManager.Services;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -40,7 +41,14 @@ namespace PackageManager.ViewModels.Commands
             if (execute)
             {
                 IPackageContent packageContent = await package.GetContentAsync(cancellationToken);
-                await packageContent.RemoveFromAsync(service.Path, cancellationToken);
+                string pluginPath = Path.Combine(service.Path, package.Id);
+                await packageContent.RemoveFromAsync(pluginPath, cancellationToken);
+
+                // do not delete the plugin directory if it still contains files (e.g. data files)
+                if (Directory.Exists(pluginPath) && !Directory.EnumerateFileSystemEntries(pluginPath).Any())
+                {
+                    Directory.Delete(pluginPath);
+                }
 
                 cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/PackageManager/ViewModels/Commands/UpdateCommand.cs
+++ b/src/PackageManager/ViewModels/Commands/UpdateCommand.cs
@@ -3,6 +3,7 @@ using Neptuo.Observables.Commands;
 using PackageManager.Models;
 using PackageManager.Services;
 using System;
+using System.IO;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -46,11 +47,12 @@ namespace PackageManager.ViewModels.Commands
                 }
 
                 IPackageContent packageContent = await package.Current.Model.GetContentAsync(cancellationToken);
-                await packageContent.RemoveFromAsync(install.Path, cancellationToken);
+                string pluginPath = Path.Combine(install.Path, package.Current.Id);
+                await packageContent.RemoveFromAsync(pluginPath, cancellationToken);
                 install.Uninstall(package.Current.Model);
 
                 packageContent = await package.Target.GetContentAsync(cancellationToken);
-                await packageContent.ExtractToAsync(install.Path, cancellationToken);
+                await packageContent.ExtractToAsync(pluginPath, cancellationToken);
                 install.Install(package.Target);
 
                 if (package.IsSelf)

--- a/test/PackageManager.Tests/ViewModels/Commands/Package.cs
+++ b/test/PackageManager.Tests/ViewModels/Commands/Package.cs
@@ -2,6 +2,7 @@
 using PackageManager.Models;
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading;
@@ -20,12 +21,12 @@ namespace PackageManager.ViewModels.Commands
         {
             Mock<IPackageContent> contentMock = new Mock<IPackageContent>();
             contentMock
-                .Setup(pc => pc.ExtractToAsync(It.Is<string>(s => s == extractPath), It.IsAny<CancellationToken>()))
+                .Setup(pc => pc.ExtractToAsync(It.Is<string>(s => s == Path.Combine(extractPath, id)), It.IsAny<CancellationToken>()))
                 .Callback(() => ExtractToAsyncCalled.Increment())
                 .Returns(() => Task.CompletedTask);
 
             contentMock
-                .Setup(pc => pc.RemoveFromAsync(It.Is<string>(s => s == extractPath), It.IsAny<CancellationToken>()))
+                .Setup(pc => pc.RemoveFromAsync(It.Is<string>(s => s == Path.Combine(extractPath, id)), It.IsAny<CancellationToken>()))
                 .Callback(() => RemoveFromAsyncCalled.Increment())
                 .Returns(() => Task.CompletedTask);
 


### PR DESCRIPTION
Closes #29.

### Proposed changes

- All content from a NuGet package is copied into a dedicated sub-dir `UserPlugins\<PackageID>`.
- Plugins are expected to write additional files (if any) only into their own sub-dir `UserPlugins\<PackageID>`. Only notable exception are the config files `NuGet.Config` and `packages.config`, which are managed by the PM. These are located directly in `UserPlugins`, since they might be of general interest.

The new directory structure is:
```
UserPlugins\
    GitExtensions.PluginManager\
        PackageManager\PackageManager.UI.exe
        GitExtensions.PluginManager.dll
    GitExtensions.SVN\
        GitExtensions.SVN.dll
    NuGet.Config
    packages.config
```
Opposed to the old structure:
```
UserPlugins\
    PackageManager\PackageManager.UI.exe
    GitExtensions.PluginManager.dll
    GitExtensions.SVN.dll
    NuGet.Config
    packages.config
```