### PR TITLE
consistent use of name "Plugin Manager"

### DIFF
--- a/src/GitExtensions.PluginManager/PluginSettings.cs
+++ b/src/GitExtensions.PluginManager/PluginSettings.cs
@@ -13,7 +13,7 @@ namespace GitExtensions.PluginManager
         /// <summary>
         /// Gets a property holding if asking to close git extensions is required.
         /// </summary>
-        public static BoolSetting CloseInstancesProperty { get; } = new BoolSetting("CloseInstances", "Close all instances of Git Extensions before starting PluginManager", false);
+        public static BoolSetting CloseInstancesProperty { get; } = new BoolSetting("CloseInstances", "Close all instances of Git Extensions before starting Plugin Manager", false);
 
         private readonly ISettingsSource source;
 

--- a/src/PackageManager.UI/App.xaml.cs
+++ b/src/PackageManager.UI/App.xaml.cs
@@ -56,7 +56,7 @@ namespace PackageManager
 
             if (!Directory.Exists(Args.Path))
             {
-                Navigator.Notify("Packages", "Missing argument '--path' - a target path to install packages to.", Navigator.MessageType.Error);
+                Navigator.Notify("Plugin Manager", "Missing argument '--path' - a target path to install packages to.", Navigator.MessageType.Error);
                 Shutdown();
                 return;
             }
@@ -194,13 +194,13 @@ namespace PackageManager
                         }
                         else
                         {
-                            Navigator.Notify("Self Update Error", $"Unnable to find update package (version {Args.SelfUpdateVersion}) for PackageManager.", Navigator.MessageType.Error);
+                            Navigator.Notify("Self Update Error", $"Unnable to find update package (version {Args.SelfUpdateVersion}) for Plugin Manager.", Navigator.MessageType.Error);
                         }
                     }
                 }
                 else
                 {
-                    Navigator.Notify("Self Update Error", $"Unnable to find update package for PackageManager.", Navigator.MessageType.Error);
+                    Navigator.Notify("Self Update Error", $"Unnable to find update package for Plugin Manager.", Navigator.MessageType.Error);
                 }
 
                 if (canUpdate)

--- a/src/PackageManager.UI/Views/MainWindow.xaml
+++ b/src/PackageManager.UI/Views/MainWindow.xaml
@@ -8,7 +8,7 @@
         xmlns:converters="clr-namespace:PackageManager.Views.Converters"
         xmlns:views="clr-namespace:PackageManager.Views"
         mc:Ignorable="d" d:DataContext="{x:Static dd:ViewModelLocator.Main}"
-        Title="Packages" Height="600" Width="800" Icon="{StaticResource AppIcon}" WindowStartupLocation="CenterScreen">
+        Title="Plugin Manager" Height="600" Width="800" Icon="{StaticResource AppIcon}" WindowStartupLocation="CenterScreen">
     <Window.Resources>
         <converters:ValidUrlToTrueConverter x:Key="ValidUrlToTrueConverter" />
     </Window.Resources>

--- a/src/PackageManager.UI/Views/MainWindow.xaml.cs
+++ b/src/PackageManager.UI/Views/MainWindow.xaml.cs
@@ -52,7 +52,7 @@ namespace PackageManager.Views
             if (context.IsExecutable)
             {
                 bool result = navigator.Confirm(
-                    "PluginManager",
+                    "Plugin Manager",
                     "Plugin Manager is going to write to files that are holded by other executables. " + Environment.NewLine +
                     "Do you want to kill all instances of these applications?"
                 );


### PR DESCRIPTION
Resolves #37 

## Proposed changes

* use "Plugin Manager" everywhere

Note: I didn't change the name of the executable `PackageManager.UI.exe`, nor of the VS projects `PackageManager.*`. That seemed to be overkill to me.