### PR TITLE
Fix regression introduced in PR #36

### DIFF
--- a/src/GitExtensions.PluginManager/GitExtensions.PluginManager.csproj
+++ b/src/GitExtensions.PluginManager/GitExtensions.PluginManager.csproj
@@ -54,8 +54,9 @@
     </EmbeddedResource>
   </ItemGroup>
   
-  <Target Name="CopyPackageManager" AfterTargets="ResolveReferences">
-    <Copy SourceFiles="$(PackageManagerSourcePath)" DestinationFolder="$(TargetDir)PackageManager" />
+  <Target Name="CopyPackageManager" AfterTargets="PostBuildEvent">
+    <Copy SourceFiles="$(PackageManagerSourcePath)" DestinationFiles="$(TargetDir)$(PackageManagerTargetPath)" />
+    <Copy SourceFiles="$(PackageManagerSourcePath)" DestinationFiles="$(GitExtensionsPluginsPath)\$(ProjectName)\$(PackageManagerTargetPath)" />
   </Target>
   <Target Name="PreClean" BeforeTargets="Clean">
     <Message Text="Deleting PackageManager" Importance="high" />


### PR DESCRIPTION
In PR #36 I've overseen that 2 different targets in `GitExtensions.PluginManager.csproj` were copying the file `PackageManager.UI.exe` to different locations:
1) `$(TargetDir)\PackageManager\PackageManager.UI.exe` for building the NuGet package
2) `$(GitExtensionsPluginsPath)\$(ProjectName)\PackageManager\PackageManager.UI.exe` for local testing and debugging.

As a result, the second copy was erroneously removed.

The original targets (previous to #36) were:
https://github.com/gitextensions/gitextensions.pluginmanager/blob/4d9433e95f5d954d24fdb0317420fb54bf07e61f/src/GitExtensions.PluginManager/GitExtensions.PluginManager.csproj#L59-L65

This PR now restores the second copy, in order to use the correct `PackageManager.UI.exe` locally for debugging and testing.