### PR TITLE
Fix plugin settings for GitExtensions-v3.3.1

### DIFF
--- a/src/GitExtensions.PluginManager/GitExtensions.PluginManager.csproj
+++ b/src/GitExtensions.PluginManager/GitExtensions.PluginManager.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitExtensions.Extensibility" Version="0.1.1" />
+    <PackageReference Include="GitExtensions.Extensibility" Version="0.1.*" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/GitExtensions.PluginManager/Plugin.cs
+++ b/src/GitExtensions.PluginManager/Plugin.cs
@@ -29,6 +29,7 @@ namespace GitExtensions.PluginManager
         internal PluginSettings Configuration { get; private set; }
 
         public Plugin()
+            : base(PluginSettings.HasProperties)
         {
             Name = "Plugin Manager";
             Description = "Plugin Manager";

--- a/src/GitExtensions.PluginManager/PluginSettings.cs
+++ b/src/GitExtensions.PluginManager/PluginSettings.cs
@@ -31,6 +31,8 @@ namespace GitExtensions.PluginManager
 
         private static readonly List<ISetting> properties;
 
+        public static bool HasProperties => properties.Count > 0;
+
         static PluginSettings()
         {
             properties = new List<ISetting>(1)


### PR DESCRIPTION
Fixes #42.

- Use wildcard patch version for GitExtensions.Extensibility package reference.
- Use base constructor of GitPluginBase with boolean parameter to indicate that plugin has settings.