### PR TITLE
Package details

### DIFF
--- a/src/PackageManager.UI/Views/Browser.xaml
+++ b/src/PackageManager.UI/Views/Browser.xaml
@@ -5,6 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:dd="clr-namespace:PackageManager.Views.DesignData"
              xmlns:controls="clr-namespace:PackageManager.Views.Controls"
+             xmlns:views="clr-namespace:PackageManager.Views"
              mc:Ignorable="d" d:DesignHeight="450" d:DesignWidth="800" d:DataContext="{Binding Source={x:Static dd:ViewModelLocator.Browser}}" Background="White">
     <DockPanel x:Name="MainPanel">
         <StackPanel Margin="8" DockPanel.Dock="Top">
@@ -41,7 +42,7 @@
                             <RowDefinition Height="Auto" />
                         </Grid.RowDefinitions>
 
-                        <ListView x:Name="lvwPackages" ItemsSource="{Binding Packages}" SelectionChanged="lvwPackages_SelectionChanged" BorderThickness="0" ScrollViewer.HorizontalScrollBarVisibility="Disabled">
+                        <ListView x:Name="lvwPackages" SelectedItem="{Binding SelectedPackage, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=views:Browser}}" ItemsSource="{Binding Packages}" SelectionChanged="lvwPackages_SelectionChanged" BorderThickness="0" ScrollViewer.HorizontalScrollBarVisibility="Disabled">
                             <ListView.ItemTemplate>
                                 <DataTemplate>
                                     <Border Padding="8">
@@ -78,105 +79,39 @@
                 </Border>
 
                 <Border BorderThickness="1" BorderBrush="{StaticResource BorderBrush}" Margin="4,4,8,8" Grid.Column="1">
-                    <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
-                        <StackPanel Margin="8" DataContext="{Binding SelectedItem, ElementName=lvwPackages}" d:DataContext="{Binding Source={x:Static dd:ViewModelLocator.PackageViewModel}}" Visibility="{Binding Converter={StaticResource NullToCollapsedConverter}}">
-                            <StackPanel Orientation="Horizontal">
-                                <StackPanel.DataContext>
+                    <DockPanel Margin="8">
+                        <views:PackageName DockPanel.Dock="Top">
+                            <views:PackageName.Model>
+                                <MultiBinding Converter="{StaticResource FirstNotNullMultiConverter}">
+                                    <Binding Path="SelectedVersion.Model" RelativeSource="{RelativeSource Mode=FindAncestor, AncestorType=views:Browser}" />
+                                    <Binding Path="SelectedPackage.Model" RelativeSource="{RelativeSource Mode=FindAncestor, AncestorType=views:Browser}" />
+                                </MultiBinding>
+                            </views:PackageName.Model>
+                        </views:PackageName>
+                        <StackPanel DataContext="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=views:Browser}}" Margin="0,8" Orientation="Horizontal" HorizontalAlignment="Left" DockPanel.Dock="Top">
+                            <Button Content="Install" Command="{Binding ViewModel.Install}" Margin="0,0,8,0">
+                                <Button.CommandParameter>
                                     <MultiBinding Converter="{StaticResource FirstNotNullMultiConverter}">
-                                        <Binding Path="SelectedItem" ElementName="cbxVersions" />
-                                        <Binding />
+                                        <Binding Path="SelectedVersion.Model" />
+                                        <Binding Path="SelectedPackage.Model" />
                                     </MultiBinding>
-                                </StackPanel.DataContext>
-                                
-                                <Image Source="{Binding IconUrl, Converter={StaticResource NullToDefaultIconConverter}}" Width="33" Height="34" Margin="0,4,8,0" VerticalAlignment="Top" DockPanel.Dock="Left" />
-                                <TextBox Text="{Binding Id, Mode=OneWay}" Style="{StaticResource ReadOnlyTextBoxStyle}" FontSize="20" VerticalAlignment="Center" />
-                            </StackPanel>
+                                </Button.CommandParameter>
+                            </Button>
 
-                            <Grid Margin="0,8">
-                                <StackPanel Orientation="Horizontal" HorizontalAlignment="Left">
-                                    <Button Content="Install" Command="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=Border}, Path=DataContext.Install}" Margin="0,0,8,0">
-                                        <Button.CommandParameter>
-                                            <MultiBinding Converter="{StaticResource FirstNotNullMultiConverter}">
-                                                <Binding Path="SelectedItem.Model" ElementName="cbxVersions" />
-                                                <Binding Path="Model" />
-                                            </MultiBinding>
-                                        </Button.CommandParameter>
-                                    </Button>
-
-                                    <Button Content="Other versions.." Command="{Binding LoadVersions}" Visibility="{Binding AreVersionsLoaded, Converter={StaticResource FalseToVisibleConverter}}" MinWidth="100" MaxWidth="100" />
-                                    <ComboBox x:Name="cbxVersions" ItemsSource="{Binding Versions}" SelectedItem="{Binding Mode=OneWay}" DisplayMemberPath="Version" ItemStringFormat="{}v{0}" 
-                                     SelectionChanged="cbxVersions_SelectionChanged"
-                                     Visibility="{Binding AreVersionsLoaded, Converter={StaticResource TrueToVisibleConverter}}" MinWidth="100" MaxWidth="100" />
-                                </StackPanel>
-                            </Grid>
-
-                            <StackPanel>
-                                <StackPanel.DataContext>
-                                    <MultiBinding Converter="{StaticResource FirstNotNullMultiConverter}">
-                                        <Binding Path="SelectedItem" ElementName="cbxVersions" />
-                                        <Binding />
-                                    </MultiBinding>
-                                </StackPanel.DataContext>
-                                
-                                <TextBox Text="{Binding Description, Mode=OneWay}" Style="{StaticResource ReadOnlyTextBoxStyle}" TextWrapping="Wrap" />
-
-                                <Grid Margin="0,8,0,0">
-                                    <Grid.Resources>
-                                        <Style TargetType="TextBlock">
-                                            <Setter Property="TextWrapping" Value="Wrap" />
-                                        </Style>
-                                    </Grid.Resources>
-
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="0.5*"/>
-                                        <ColumnDefinition/>
-                                    </Grid.ColumnDefinitions>
-                                    <Grid.RowDefinitions>
-                                        <RowDefinition/>
-                                        <RowDefinition/>
-                                        <RowDefinition/>
-                                        <RowDefinition/>
-                                        <RowDefinition/>
-                                        <RowDefinition/>
-                                    </Grid.RowDefinitions>
-
-                                    <!-- Version -->
-                                    <Label Grid.Row="0" Grid.Column="0" Content="Version:" />
-                                    <TextBlock Grid.Row="0" Grid.Column="1">
-                                        <Run Text="v" /><Run Text="{Binding Version, Mode=OneWay}" />
-                                    </TextBlock>
-
-                                    <!-- Authors -->
-                                    <Label Grid.Row="1" Grid.Column="0" Content="Authors:" />
-                                    <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding Authors, Mode=OneWay}" />
-
-                                    <!-- License URL -->
-                                    <Label Grid.Row="2" Grid.Column="0" Content="License URL:" />
-                                    <TextBlock Grid.Row="2" Grid.Column="1">
-                                        <Hyperlink NavigateUri="{Binding LicenseUrl, Mode=OneWay}" ToolTip="{Binding LicenseUrl, Mode=OneWay}" RequestNavigate="Hyperlink_RequestNavigate">
-                                            <Run Text="{Binding LicenseUrl, Mode=OneWay}"/>
-                                        </Hyperlink>
-                                    </TextBlock>
-
-                                    <!-- Published Date -->
-                                    <Label Grid.Row="3" Grid.Column="0" Content="Published Date:" Visibility="{Binding Published, Converter={StaticResource NullToCollapsedConverter}}"/>
-                                    <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding Published, Mode=OneWay}" Visibility="{Binding Published, Converter={StaticResource NullToCollapsedConverter}}" />
-
-                                    <!-- Project URL -->
-                                    <Label Grid.Row="4" Grid.Column="0" Content="Project URL:" />
-                                    <TextBlock Grid.Row="4" Grid.Column="1">
-                                        <Hyperlink NavigateUri="{Binding ProjectUrl, Mode=OneWay}" ToolTip="{Binding ProjectUrl, Mode=OneWay}" RequestNavigate="Hyperlink_RequestNavigate">
-                                            <Run Text="{Binding ProjectUrl, Mode=OneWay}"/>
-                                        </Hyperlink>
-                                    </TextBlock>
-
-                                    <!-- Tags -->
-                                    <Label Grid.Row="5" Grid.Column="0" Content="Tags:" />
-                                    <TextBlock Grid.Row="6" Grid.Column="1" Text="{Binding Tags, Mode=OneWay}" Margin="0,0,0,8" />
-                                </Grid>
-                            </StackPanel>
+                            <Button Content="Other versions.." Command="{Binding SelectedPackage.LoadVersions}" Visibility="{Binding SelectedPackage.AreVersionsLoaded, Converter={StaticResource FalseToVisibleConverter}}" MinWidth="100" MaxWidth="100" />
+                            <ComboBox ItemsSource="{Binding SelectedPackage.Versions}" SelectedItem="{Binding SelectedVersion}" DisplayMemberPath="Version" ItemStringFormat="{}v{0}" 
+                             SelectionChanged="cbxVersions_SelectionChanged"
+                             Visibility="{Binding SelectedPackage.AreVersionsLoaded, Converter={StaticResource TrueToVisibleConverter}}" MinWidth="100" MaxWidth="100" />
                         </StackPanel>
-                    </ScrollViewer>
+                        <views:PackageDetail>
+                            <views:PackageDetail.Model>
+                                <MultiBinding Converter="{StaticResource FirstNotNullMultiConverter}">
+                                    <Binding Path="SelectedVersion.Model" RelativeSource="{RelativeSource Mode=FindAncestor, AncestorType=views:Browser}" />
+                                    <Binding Path="SelectedPackage.Model" RelativeSource="{RelativeSource Mode=FindAncestor, AncestorType=views:Browser}" />
+                                </MultiBinding>
+                            </views:PackageDetail.Model>
+                        </views:PackageDetail>
+                    </DockPanel>
                 </Border>
             </Grid>
 

--- a/src/PackageManager.UI/Views/Browser.xaml.cs
+++ b/src/PackageManager.UI/Views/Browser.xaml.cs
@@ -1,7 +1,6 @@
 ﻿using PackageManager.ViewModels;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -36,6 +35,38 @@ namespace PackageManager.Views
         {
             Browser view = (Browser)d;
             view.OnViewModelChanged((BrowserViewModel)e.OldValue, (BrowserViewModel)e.NewValue);
+        }
+
+
+        internal PackageViewModel SelectedPackage
+        {
+            get { return (PackageViewModel)GetValue(SelectedPackageProperty); }
+            set { SetValue(SelectedPackageProperty, value); }
+        }
+
+        internal static readonly DependencyProperty SelectedPackageProperty = DependencyProperty.Register(
+            "SelectedPackage", 
+            typeof(PackageViewModel), 
+            typeof(Browser), 
+            new PropertyMetadata(null)
+        );
+
+
+        internal PackageViewModel SelectedVersion
+        {
+            get { return (PackageViewModel)GetValue(SelectedVersionProperty); }
+            set { SetValue(SelectedVersionProperty, value); }
+        }
+
+        internal static readonly DependencyProperty SelectedVersionProperty = DependencyProperty.Register(
+            "SelectedVersion", 
+            typeof(PackageViewModel), 
+            typeof(Browser), 
+            new PropertyMetadata(null, OnSelectedVersionChanged)
+        );
+
+        private static void OnSelectedVersionChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
         }
 
         public Browser()
@@ -74,14 +105,11 @@ namespace PackageManager.Views
             UpdateInitialMessage(false);
         }
 
-        private void Hyperlink_RequestNavigate(object sender, RequestNavigateEventArgs e)
-        {
-            Process.Start(e.Uri.AbsoluteUri);
-            e.Handled = true;
-        }
-
         private void lvwPackages_SelectionChanged(object sender, SelectionChangedEventArgs e)
-            => RaiseCanExecuteChangedOnCommands();
+        {
+            SelectedVersion = (PackageViewModel)lvwPackages.SelectedItem;
+            RaiseCanExecuteChangedOnCommands();
+        }
 
         private void cbxVersions_SelectionChanged(object sender, SelectionChangedEventArgs e)
             => RaiseCanExecuteChangedOnCommands();

--- a/src/PackageManager.UI/Views/Installed.xaml
+++ b/src/PackageManager.UI/Views/Installed.xaml
@@ -5,6 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:dd="clr-namespace:PackageManager.Views.DesignData"
              xmlns:controls="clr-namespace:PackageManager.Views.Controls"
+             xmlns:views="clr-namespace:PackageManager.Views"
              mc:Ignorable="d" d:DesignHeight="450" d:DesignWidth="800" d:DataContext="{Binding Source={x:Static dd:ViewModelLocator.Installed}}" Background="White">
     <DockPanel x:Name="MainPanel">
         <Grid DockPanel.Dock="Top">
@@ -16,34 +17,52 @@
             </StackPanel>
         </Grid>
 
-        <ListView x:Name="lvwPackages" ItemsSource="{Binding Packages}" HorizontalContentAlignment="Stretch" Margin="8,0,8,8" ScrollViewer.HorizontalScrollBarVisibility="Disabled">
-            <ListView.ItemTemplate>
-                <DataTemplate>
-                    <Border Padding="8">
-                        <DockPanel>
-                            <Image Source="{Binding Definition.IconUrl, Converter={StaticResource NullToDefaultIconConverter}}" Width="33" Height="34" Margin="0,4,8,0" VerticalAlignment="Top" DockPanel.Dock="Left" />
-                            <StackPanel VerticalAlignment="Center" Margin="8,0,0,0" DockPanel.Dock="Right">
-                                <Button Content="Uninstall" Command="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=ListView}, Path=DataContext.Uninstall}" CommandParameter="{Binding Definition}" Margin="0,0,0,8" />
-                                <Button Content="Reinstall" Command="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=ListView}, Path=DataContext.Reinstall}" CommandParameter="{Binding Definition}" />
-                            </StackPanel>
-                            <StackPanel>
-                                <Grid>
-                                    <StackPanel Orientation="Horizontal">
-                                        <TextBlock Text="{Binding Definition.Id}" FontWeight="Bold" />
-                                        <TextBlock Text=" (PackageManager)" Visibility="{Binding Definition, Converter={StaticResource SelfPackageToVisibleConverter}}" />
-                                        <controls:CompatibilityLabel IsCompatible="{Binding IsCompatible}" />
-                                    </StackPanel>
-                                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-                                        <TextBlock Text="v" />
-                                        <TextBlock Text="{Binding Definition.Version}" />
-                                    </StackPanel>
-                                </Grid>
-                                <TextBlock Text="{Binding Definition.Description, Converter={StaticResource DropNewLineConverter}}" Margin="0,8,0,0" TextTrimming="CharacterEllipsis" />
-                            </StackPanel>
-                        </DockPanel>
-                    </Border>
-                </DataTemplate>
-            </ListView.ItemTemplate>
-        </ListView>
+        <Grid>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+
+            <ListView x:Name="lvwPackages" ItemsSource="{Binding Packages}" SelectedItem="{Binding SelectedPackage, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=views:Installed}}" SelectionChanged="lvwPackages_SelectionChanged" HorizontalContentAlignment="Stretch" Margin="8,0,8,8" ScrollViewer.HorizontalScrollBarVisibility="Disabled">
+                <ListView.ItemTemplate>
+                    <DataTemplate>
+                        <Border Padding="8">
+                            <DockPanel>
+                                <Image Source="{Binding Definition.IconUrl, Converter={StaticResource NullToDefaultIconConverter}}" Width="33" Height="34" Margin="0,4,8,0" VerticalAlignment="Top" DockPanel.Dock="Left" />
+                                <StackPanel>
+                                    <Grid>
+                                        <StackPanel Orientation="Horizontal">
+                                            <TextBlock Text="{Binding Definition.Id}" FontWeight="Bold" />
+                                            <TextBlock Text=" (PackageManager)" Visibility="{Binding Definition, Converter={StaticResource SelfPackageToVisibleConverter}}" />
+                                            <controls:CompatibilityLabel IsCompatible="{Binding IsCompatible}" />
+                                        </StackPanel>
+                                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                                            <TextBlock Text="v" />
+                                            <TextBlock Text="{Binding Definition.Version}" />
+                                        </StackPanel>
+                                    </Grid>
+                                    <TextBlock Text="{Binding Definition.Description, Converter={StaticResource DropNewLineConverter}}" Margin="0,8,0,0" TextTrimming="CharacterEllipsis" />
+                                </StackPanel>
+                            </DockPanel>
+                        </Border>
+                    </DataTemplate>
+                </ListView.ItemTemplate>
+            </ListView>
+
+            <Border BorderThickness="1" BorderBrush="{StaticResource BorderBrush}" Margin="4,0,8,8" Grid.Column="1">
+                <DockPanel Margin="8" Visibility="{Binding SelectedPackage, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=views:Installed}, Converter={StaticResource NullToCollapsedConverter}}">
+                    <views:PackageName Model="{Binding SelectedPackage.Definition, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=views:Installed}}" DockPanel.Dock="Top" />
+                    <StackPanel DataContext="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=views:Installed}}" Margin="0,8" Orientation="Horizontal" HorizontalAlignment="Left" DockPanel.Dock="Top">
+                        <Button Content="Uninstall" Command="{Binding ViewModel.Uninstall}" CommandParameter="{Binding SelectedPackage.Definition}" Margin="0,0,8,0" />
+                        <Button Content="Reinstall" Command="{Binding ViewModel.Reinstall}" CommandParameter="{Binding SelectedPackage.Definition}" Margin="0" />
+                    </StackPanel>
+                    <views:PackageDetail Model="{Binding SelectedPackage.Definition, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=views:Installed}}" />
+                </DockPanel>
+            </Border>
+        </Grid>
     </DockPanel>
 </UserControl>

--- a/src/PackageManager.UI/Views/Installed.xaml.cs
+++ b/src/PackageManager.UI/Views/Installed.xaml.cs
@@ -1,4 +1,5 @@
-﻿using PackageManager.ViewModels;
+﻿using PackageManager.Models;
+using PackageManager.ViewModels;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -37,6 +38,20 @@ namespace PackageManager.Views
             view.OnViewModelChanged((InstalledViewModel)e.OldValue, (InstalledViewModel)e.NewValue);
         }
 
+
+        internal IInstalledPackage SelectedPackage
+        {
+            get { return (IInstalledPackage)GetValue(SelectedPackageProperty); }
+            set { SetValue(SelectedPackageProperty, value); }
+        }
+
+        internal static readonly DependencyProperty SelectedPackageProperty = DependencyProperty.Register(
+            "SelectedPackage",
+            typeof(IInstalledPackage),
+            typeof(Installed),
+            new PropertyMetadata(null)
+        );
+
         public Installed()
         {
             InitializeComponent();
@@ -60,6 +75,12 @@ namespace PackageManager.Views
         {
             ViewModel.Refresh.Execute();
             lvwPackages.Focus();
+        }
+
+        private void lvwPackages_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            ViewModel.Uninstall.RaiseCanExecuteChanged();
+            ViewModel.Reinstall.RaiseCanExecuteChanged();
         }
     }
 }

--- a/src/PackageManager.UI/Views/PackageDetail.xaml
+++ b/src/PackageManager.UI/Views/PackageDetail.xaml
@@ -1,0 +1,68 @@
+﻿<UserControl x:Class="PackageManager.Views.PackageDetail" x:Name="root"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"  
+             xmlns:dd="clr-namespace:PackageManager.Views.DesignData"
+             mc:Ignorable="d" d:DesignHeight="450" d:DesignWidth="350" Background="White">
+    <ScrollViewer HorizontalScrollBarVisibility="Disabled" VerticalScrollBarVisibility="Auto">
+        <StackPanel d:DataContext="{Binding Source={x:Static dd:ViewModelLocator.Package}}" Visibility="{Binding Converter={StaticResource NullToCollapsedConverter}}">
+            <TextBox Text="{Binding Description, Mode=OneWay}" Style="{StaticResource ReadOnlyTextBoxStyle}" TextWrapping="Wrap" />
+
+            <Grid Margin="0,8,0,0">
+                <Grid.Resources>
+                    <Style TargetType="TextBlock">
+                        <Setter Property="TextWrapping" Value="Wrap" />
+                    </Style>
+                </Grid.Resources>
+
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="0.5*"/>
+                    <ColumnDefinition/>
+                </Grid.ColumnDefinitions>
+                <Grid.RowDefinitions>
+                    <RowDefinition/>
+                    <RowDefinition/>
+                    <RowDefinition/>
+                    <RowDefinition/>
+                    <RowDefinition/>
+                    <RowDefinition/>
+                </Grid.RowDefinitions>
+
+                <!-- Version -->
+                <Label Grid.Row="0" Grid.Column="0" Content="Version:" />
+                <TextBlock Grid.Row="0" Grid.Column="1">
+                    <Run Text="v" /><Run Text="{Binding Version, Mode=OneWay}" />
+                </TextBlock>
+
+                <!-- Authors -->
+                <Label Grid.Row="1" Grid.Column="0" Content="Authors:" />
+                <TextBlock Grid.Row="1" Grid.Column="1" Text="{Binding Authors, Mode=OneWay}" />
+
+                <!-- License URL -->
+                <Label Grid.Row="2" Grid.Column="0" Content="License URL:" />
+                <TextBlock Grid.Row="2" Grid.Column="1">
+                    <Hyperlink NavigateUri="{Binding LicenseUrl, Mode=OneWay}" ToolTip="{Binding LicenseUrl, Mode=OneWay}" RequestNavigate="Hyperlink_RequestNavigate">
+                        <Run Text="{Binding LicenseUrl, Mode=OneWay}"/>
+                    </Hyperlink>
+                </TextBlock>
+
+                <!-- Published Date -->
+                <Label Grid.Row="3" Grid.Column="0" Content="Published Date:" Visibility="{Binding Published, Converter={StaticResource NullToCollapsedConverter}}"/>
+                <TextBlock Grid.Row="3" Grid.Column="1" Text="{Binding Published, Mode=OneWay}" Visibility="{Binding Published, Converter={StaticResource NullToCollapsedConverter}}" />
+
+                <!-- Project URL -->
+                <Label Grid.Row="4" Grid.Column="0" Content="Project URL:" />
+                <TextBlock Grid.Row="4" Grid.Column="1">
+                    <Hyperlink NavigateUri="{Binding ProjectUrl, Mode=OneWay}" ToolTip="{Binding ProjectUrl, Mode=OneWay}" RequestNavigate="Hyperlink_RequestNavigate">
+                        <Run Text="{Binding ProjectUrl, Mode=OneWay}"/>
+                    </Hyperlink>
+                </TextBlock>
+
+                <!-- Tags -->
+                <Label Grid.Row="5" Grid.Column="0" Content="Tags:" />
+                <TextBlock Grid.Row="6" Grid.Column="1" Text="{Binding Tags, Mode=OneWay}" Margin="0,0,0,8" />
+            </Grid>
+        </StackPanel>
+    </ScrollViewer>
+</UserControl>

--- a/src/PackageManager.UI/Views/PackageDetail.xaml.cs
+++ b/src/PackageManager.UI/Views/PackageDetail.xaml.cs
@@ -1,0 +1,53 @@
+﻿using PackageManager.Models;
+using PackageManager.ViewModels;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace PackageManager.Views
+{
+    public partial class PackageDetail : UserControl
+    {
+        public IPackage Model
+        {
+            get { return (IPackage)GetValue(ViewModelProperty); }
+            set { SetValue(ViewModelProperty, value); }
+        }
+
+        public static readonly DependencyProperty ViewModelProperty = DependencyProperty.Register(
+            "Model", 
+            typeof(IPackage), 
+            typeof(PackageDetail), 
+            new PropertyMetadata(null, OnModelChanged)
+        );
+
+        private static void OnModelChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            PackageDetail view = (PackageDetail)d;
+            view.DataContext = view.Model;
+        }
+
+        public PackageDetail()
+        {
+            InitializeComponent();
+        }
+
+        private void Hyperlink_RequestNavigate(object sender, RequestNavigateEventArgs e)
+        {
+            Process.Start(e.Uri.AbsoluteUri);
+            e.Handled = true;
+        }
+    }
+}

--- a/src/PackageManager.UI/Views/PackageName.xaml
+++ b/src/PackageManager.UI/Views/PackageName.xaml
@@ -1,0 +1,12 @@
+﻿<UserControl x:Class="PackageManager.Views.PackageName" x:Name="root"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"  
+             xmlns:dd="clr-namespace:PackageManager.Views.DesignData"
+             mc:Ignorable="d" d:DesignWidth="350" Background="White">
+    <StackPanel Orientation="Horizontal" d:DataContext="{Binding Source={x:Static dd:ViewModelLocator.Package}}" Visibility="{Binding Converter={StaticResource NullToCollapsedConverter}}">
+        <Image Source="{Binding IconUrl, Converter={StaticResource NullToDefaultIconConverter}}" Width="33" Height="34" Margin="0,4,8,0" VerticalAlignment="Top" DockPanel.Dock="Left" />
+        <TextBox Text="{Binding Id, Mode=OneWay}" Style="{StaticResource ReadOnlyTextBoxStyle}" FontSize="20" VerticalAlignment="Center" />
+    </StackPanel>
+</UserControl>

--- a/src/PackageManager.UI/Views/PackageName.xaml.cs
+++ b/src/PackageManager.UI/Views/PackageName.xaml.cs
@@ -1,0 +1,47 @@
+﻿using PackageManager.Models;
+using PackageManager.ViewModels;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace PackageManager.Views
+{
+    public partial class PackageName : UserControl
+    {
+        public IPackage Model
+        {
+            get { return (IPackage)GetValue(ViewModelProperty); }
+            set { SetValue(ViewModelProperty, value); }
+        }
+
+        public static readonly DependencyProperty ViewModelProperty = DependencyProperty.Register(
+            "Model", 
+            typeof(IPackage), 
+            typeof(PackageName), 
+            new PropertyMetadata(null, OnModelChanged)
+        );
+
+        private static void OnModelChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+        {
+            PackageName view = (PackageName)d;
+            view.DataContext = view.Model;
+        }
+
+        public PackageName()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/src/PackageManager.UI/Views/Updates.xaml
+++ b/src/PackageManager.UI/Views/Updates.xaml
@@ -4,6 +4,7 @@
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
              xmlns:dd="clr-namespace:PackageManager.Views.DesignData"
+             xmlns:views="clr-namespace:PackageManager.Views"
              mc:Ignorable="d" d:DesignHeight="450" d:DesignWidth="800" d:DataContext="{Binding Source={x:Static dd:ViewModelLocator.Updates}}" Background="White">
     <DockPanel x:Name="MainPanel">
         <Grid DockPanel.Dock="Top">
@@ -16,39 +17,58 @@
             </StackPanel>
         </Grid>
 
-        <ListView x:Name="lvwPackages" ItemsSource="{Binding Packages}" HorizontalContentAlignment="Stretch" Margin="8,0,8,8" ScrollViewer.HorizontalScrollBarVisibility="Disabled">
-            <ListView.ItemTemplate>
-                <DataTemplate>
-                    <Border Padding="8">
-                        <DockPanel>
-                            <Image Source="{Binding Target.IconUrl, Converter={StaticResource NullToDefaultIconConverter}}" Width="33" Height="34" Margin="0,4,8,0" VerticalAlignment="Top" DockPanel.Dock="Left" />
-                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right" VerticalAlignment="Center" Margin="8,0,0,0" DockPanel.Dock="Right">
-                                <Button Content="Update" Command="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=ListView}, Path=DataContext.Update}" CommandParameter="{Binding}" Margin="0,0,8,0" />
+        <Grid>
+            <Grid Visibility="{Binding Packages.Count, Converter={StaticResource GreaterThanZeroToVisibleConverter}}">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="*" />
+                    <RowDefinition Height="Auto" />
+                </Grid.RowDefinitions>
 
-                                <Button Content="Other versions.." Command="{Binding Current.LoadVersions}" Visibility="{Binding Current.AreVersionsLoaded, Converter={StaticResource FalseToVisibleConverter}}" MinWidth="100" MaxWidth="100" />
-                                <ComboBox x:Name="cbxVersions" ItemsSource="{Binding Current.Versions}" SelectedValue="{Binding Target, Mode=TwoWay}" SelectedValuePath="Model" DisplayMemberPath="Version" ItemStringFormat="{}v{0}" 
-                                 Visibility="{Binding Current.AreVersionsLoaded, Converter={StaticResource TrueToVisibleConverter}}" MinWidth="100" MaxWidth="100" />
-                            </StackPanel>
-                            <StackPanel>
-                                <Grid>
-                                    <StackPanel Orientation="Horizontal">
-                                        <TextBlock Text="{Binding Target.Id}" FontWeight="Bold" />
-                                        <TextBlock Text=" (PackageManager update)" Visibility="{Binding IsSelf, Converter={StaticResource TrueToVisibleConverter}}" />
+                <ListView x:Name="lvwPackages" SelectedItem="{Binding SelectedPackage, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=views:Updates}}" ItemsSource="{Binding Packages}" SelectionChanged="lvwPackages_SelectionChanged" HorizontalContentAlignment="Stretch" Margin="8,0,8,8" ScrollViewer.HorizontalScrollBarVisibility="Disabled">
+                    <ListView.ItemTemplate>
+                        <DataTemplate>
+                            <Border Padding="8">
+                                <DockPanel>
+                                    <Image Source="{Binding Target.IconUrl, Converter={StaticResource NullToDefaultIconConverter}}" Width="33" Height="34" Margin="0,4,8,0" VerticalAlignment="Top" DockPanel.Dock="Left" />
+                                    <StackPanel>
+                                        <Grid>
+                                            <StackPanel Orientation="Horizontal">
+                                                <TextBlock Text="{Binding Target.Id}" FontWeight="Bold" />
+                                                <TextBlock Text=" (PackageManager update)" Visibility="{Binding IsSelf, Converter={StaticResource TrueToVisibleConverter}}" />
+                                            </StackPanel>
+                                            <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                                                <TextBlock Text="v" />
+                                                <TextBlock Text="{Binding Current.Version}" />
+                                                <TextBlock Text=" → " />
+                                                <TextBlock Text="v" />
+                                                <TextBlock Text="{Binding Target.Version}" />
+                                            </StackPanel>
+                                        </Grid>
+                                        <TextBlock Text="{Binding Target.Description, Converter={StaticResource DropNewLineConverter}}" Margin="0,8,0,0" TextTrimming="CharacterEllipsis" />
                                     </StackPanel>
-                                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
-                                        <TextBlock Text="v" />
-                                        <TextBlock Text="{Binding Current.Version}" />
-                                        <TextBlock Text=" → " />
-                                        <TextBlock Text="v" />
-                                        <TextBlock Text="{Binding Target.Version}" />
-                                    </StackPanel>
-                                </Grid>
-                                <TextBlock Text="{Binding Target.Description, Converter={StaticResource DropNewLineConverter}}" Margin="0,8,0,0" TextTrimming="CharacterEllipsis" />
-                            </StackPanel>
-                        </DockPanel>
-                    </Border>
-                </DataTemplate>
-            </ListView.ItemTemplate>
-        </ListView>
+                                </DockPanel>
+                            </Border>
+                        </DataTemplate>
+                    </ListView.ItemTemplate>
+                </ListView>
+
+                <Border BorderThickness="1" BorderBrush="{StaticResource BorderBrush}" Margin="4,0,8,8" Grid.Column="1">
+                    <DockPanel Margin="8" Visibility="{Binding SelectedPackage, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=views:Updates}, Converter={StaticResource NullToCollapsedConverter}}">
+                        <views:PackageName Model="{Binding SelectedPackage.Target, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=views:Updates}}" DockPanel.Dock="Top" />
+                        <StackPanel DataContext="{Binding RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=views:Updates}}" Margin="0,8" Orientation="Horizontal" HorizontalAlignment="Left" DockPanel.Dock="Top">
+                            <Button Content="Update" Command="{Binding ViewModel.Update}" CommandParameter="{Binding SelectedPackage}" Margin="0,0,8,0" />
+                            <Button Content="Other versions.." Command="{Binding SelectedPackage.Current.LoadVersions}" Visibility="{Binding SelectedPackage.Current.AreVersionsLoaded, Converter={StaticResource FalseToVisibleConverter}}" MinWidth="100" MaxWidth="100" />
+                            <ComboBox ItemsSource="{Binding SelectedPackage.Current.Versions}" SelectedValue="{Binding SelectedPackage.Target, Mode=TwoWay}" SelectedValuePath="Model" DisplayMemberPath="Version" ItemStringFormat="{}v{0}" 
+                             Visibility="{Binding SelectedPackage.Current.AreVersionsLoaded, Converter={StaticResource TrueToVisibleConverter}}" MinWidth="100" MaxWidth="100" />
+                        </StackPanel>
+                        <views:PackageDetail Model="{Binding SelectedPackage.Target, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType=views:Updates}}" />
+                    </DockPanel>
+                </Border>
+            </Grid>
+        </Grid>
     </DockPanel>
 </UserControl>

--- a/src/PackageManager.UI/Views/Updates.xaml.cs
+++ b/src/PackageManager.UI/Views/Updates.xaml.cs
@@ -37,6 +37,21 @@ namespace PackageManager.Views
             view.OnViewModelChanged((UpdatesViewModel)e.OldValue, (UpdatesViewModel)e.NewValue);
         }
 
+
+        internal PackageUpdateViewModel SelectedPackage
+        {
+            get { return (PackageUpdateViewModel)GetValue(SelectedPackageProperty); }
+            set { SetValue(SelectedPackageProperty, value); }
+        }
+
+        internal static readonly DependencyProperty SelectedPackageProperty = DependencyProperty.Register(
+            "SelectedPackage", 
+            typeof(PackageUpdateViewModel), 
+            typeof(Updates), 
+            new PropertyMetadata(null)
+        );
+
+
         public Updates()
         {
             InitializeComponent();
@@ -60,6 +75,11 @@ namespace PackageManager.Views
         { 
             lvwPackages.Focus();
             await ViewModel.Refresh.ExecuteAsync();
+        }
+
+        private void lvwPackages_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            ViewModel.Update.RaiseCanExecuteChanged();
         }
     }
 }


### PR DESCRIPTION
#53 - Show package details on Installed and Updates tab.

I'm not happy with the level on UI code duplication in XAMLs, but can't figure out how to do better. If you accept it, I'm going to leave at as is and return to it in (near) future.

## Screenshots

![2020-12-10_105147](https://user-images.githubusercontent.com/10020471/101757384-61e96f00-3ad7-11eb-90bc-7c74e0a66ceb.png)

![2020-12-10_105311](https://user-images.githubusercontent.com/10020471/101757395-64e45f80-3ad7-11eb-92ef-6834391aa446.png)
