### PR TITLE
Use GUID, instead of plugin name, as key for plugin settings.

### DIFF
--- a/src/GitExtensions.PluginManager/GitExtensions.PluginManager.csproj.user
+++ b/src/GitExtensions.PluginManager/GitExtensions.PluginManager.csproj.user
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <GitExtensionsDownloadPath>..\..\..\gitextensions.shared</GitExtensionsDownloadPath> <!-- path is relative to $(ProjectDir) -->
     <GitExtensionsReferenceVersion>latest</GitExtensionsReferenceVersion> <!-- 'latest' or 'v3.1' (= tag from GitHub releases) or 'v3.1.0.5877' (= build number from AppVeyor)-->
-    <GitExtensionsReferenceSource>GitHub</GitExtensionsReferenceSource> <!-- 'GitHub' or 'AppYevor' -->
+    <GitExtensionsReferenceSource>AppVeyor</GitExtensionsReferenceSource> <!-- 'GitHub' or 'AppVeyor' -->
     <GitExtensionsPath></GitExtensionsPath> <!-- for local builds (no download) -->
   </PropertyGroup>
 </Project>

--- a/src/GitExtensions.PluginManager/Plugin.cs
+++ b/src/GitExtensions.PluginManager/Plugin.cs
@@ -31,6 +31,7 @@ namespace GitExtensions.PluginManager
         public Plugin()
             : base(PluginSettings.HasProperties)
         {
+            Id = new Guid("9E2ECC51-AE38-4C73-9EA1-5D5D1D88022E");
             Name = "Plugin Manager";
             Description = "Plugin Manager";
             Icon = Resources.Icon;


### PR DESCRIPTION
This change was implemented in Git Extensions with PR https://github.com/gitextensions/gitextensions/pull/8995.

This PR is to align the Plugin Manager accordingly.