### PR TITLE
Fix unit tests after #58

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -51,6 +51,7 @@ test_script:
 artifacts:
 - path: .\GitExtensions.PluginManager.*.zip
 - path: .\GitExtensions.PluginManager.*.nupkg
+- path: .\*.binlog
 
 #---------------------------------#
 #     deployment configuration    #

--- a/src/PackageManager.NuGet/Models/NuGetPackageSourceCollection.cs
+++ b/src/PackageManager.NuGet/Models/NuGetPackageSourceCollection.cs
@@ -107,7 +107,7 @@ namespace PackageManager.Models
             {
                 Sources.RemoveAt(index);
                 Sources.Insert(++index, target);
-                SavePackageSources();
+                SavePackageSources(true);
             }
 
             return index;

--- a/test/PackageManager.Tests/ViewModels/Commands/TestCommands.cs
+++ b/test/PackageManager.Tests/ViewModels/Commands/TestCommands.cs
@@ -15,7 +15,7 @@ namespace PackageManager.ViewModels.Commands
     [TestClass]
     public class TestCommands
     {
-        private const string ExtractPath = @"D:\";
+        private const string ExtractPath = @".\";
 
         [TestMethod]
         public void Install()

--- a/tools/Run-Tests.ps1
+++ b/tools/Run-Tests.ps1
@@ -1,6 +1,6 @@
 Push-Location $PSScriptRoot;
 
-dotnet test ..\test\PackageManager.NuGet.Tests\PackageManager.NuGet.Tests.csproj -c Release --no-build --test-adapter-path:.. --logger:Appveyor /property:Platform=AnyCPU
-dotnet test ..\test\PackageManager.Tests\PackageManager.Tests.csproj -c Release --no-build --test-adapter-path:.. --logger:Appveyor /property:Platform=AnyCPU
+dotnet test ..\test\PackageManager.NuGet.Tests\PackageManager.NuGet.Tests.csproj -c Release --test-adapter-path:.. --logger:Appveyor /property:Platform=AnyCPU
+dotnet test ..\test\PackageManager.Tests\PackageManager.Tests.csproj -c Release --test-adapter-path:.. --logger:Appveyor /property:Platform=AnyCPU
 
 Pop-Location;

--- a/tools/Run-Tests.ps1
+++ b/tools/Run-Tests.ps1
@@ -1,6 +1,17 @@
 Push-Location $PSScriptRoot;
 
-dotnet test ..\test\PackageManager.NuGet.Tests\PackageManager.NuGet.Tests.csproj -c Release --test-adapter-path:.. --logger:Appveyor /property:Platform=AnyCPU
-dotnet test ..\test\PackageManager.Tests\PackageManager.Tests.csproj -c Release --test-adapter-path:.. --logger:Appveyor /property:Platform=AnyCPU
+$targetPath = '..\';
+
+$isAppveyor = $True -eq $env:APPVEYOR;
+
+If (!$isAppveyor)
+{
+    Write-Host "Running locally";
+
+    $targetPath = Join-Path $targetPath 'artifacts';
+}
+
+dotnet test ..\test\PackageManager.NuGet.Tests\PackageManager.NuGet.Tests.csproj -c Release --test-adapter-path:.. --logger:Appveyor /property:Platform=AnyCPU -bl:$targetPath\build-PackageManager.NuGet.Tests.binlog
+dotnet test ..\test\PackageManager.Tests\PackageManager.Tests.csproj -c Release --test-adapter-path:.. --logger:Appveyor /property:Platform=AnyCPU -bl:$targetPath\build-PackageManager.Tests.binlog
 
 Pop-Location;


### PR DESCRIPTION
- Moving package down in sources collection wasn't working.
- Remove `--no-build` from `Run-Tests.ps1`, because we don't build whole solution in previous steps.

This is follow-up to #58.