### PR TITLE
Fix publish on .NET 5

### DIFF
--- a/tools/Prepare-Release.ps1
+++ b/tools/Prepare-Release.ps1
@@ -12,8 +12,8 @@ If (!$isAppveyor)
 }
 
 dotnet restore ..\GitExtensions.PluginManager.sln
-dotnet publish ..\src\PackageManager.UI\PackageManager.UI.csproj -c Release -p:PublishProfile=FolderProfile
-dotnet publish ..\src\GitExtensions.PluginManager\GitExtensions.PluginManager.csproj --configuration Release -verbosity:minimal
+dotnet publish ..\src\PackageManager.UI\PackageManager.UI.csproj -c Release -p:PublishSingleFile=true -p:PublishReadyToRun=true -p:RuntimeIdentifier=win-x86 -p:SelfContained=false -p:PublishDir=bin\Release\net5.0-windows\publish\ -bl:$targetPath\build-PackageManager.UI.binlog
+dotnet publish ..\src\GitExtensions.PluginManager\GitExtensions.PluginManager.csproj --configuration Release -verbosity:minimal -bl:$targetPath\build-GitExtensions.PluginManager.binlog
 if (!($LastExitCode -eq 0))
 {
     Pop-Location;


### PR DESCRIPTION
- Replace publish profile with direct arguments in Prepare-Release.ps1.
- Generate binlogs during publish.

This is follow-up to #58.