### PR TITLE
#62 - Fix opening a URL after migration to .NET 5

### DIFF
--- a/src/PackageManager.UI/Views/PackageDetail.xaml.cs
+++ b/src/PackageManager.UI/Views/PackageDetail.xaml.cs
@@ -46,7 +46,11 @@ namespace PackageManager.Views
 
         private void Hyperlink_RequestNavigate(object sender, RequestNavigateEventArgs e)
         {
-            Process.Start(e.Uri.AbsoluteUri);
+            Process.Start(new ProcessStartInfo()
+            {
+                FileName = e.Uri.AbsoluteUri,
+                UseShellExecute = true
+            });
             e.Handled = true;
         }
     }


### PR DESCRIPTION
Fixes #62.