### PR TITLE
Target Git Extensions v4.0

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@
 #---------------------------------#
 
 # version format
-version: 2.0.0.{build}
+version: 2.0.1.{build}
 
 # version suffix, if any (e.g. '-RC1', '-beta' otherwise '')
 environment:

--- a/src/GitExtensions.PluginManager/GitExtensions.PluginManager.csproj.user
+++ b/src/GitExtensions.PluginManager/GitExtensions.PluginManager.csproj.user
@@ -1,8 +1,8 @@
 <Project>
   <PropertyGroup>
     <GitExtensionsDownloadPath>..\..\..\gitextensions.shared</GitExtensionsDownloadPath> <!-- path is relative to $(ProjectDir) -->
-    <GitExtensionsReferenceVersion>latest</GitExtensionsReferenceVersion> <!-- 'latest' or 'v3.1' (= tag from GitHub releases) or 'v3.1.0.5877' (= build number from AppVeyor)-->
-    <GitExtensionsReferenceSource>AppVeyor</GitExtensionsReferenceSource> <!-- 'GitHub' or 'AppVeyor' -->
-    <GitExtensionsPath></GitExtensionsPath> <!-- for local builds (no download) -->
+    <GitExtensionsReferenceVersion>v4.0.1</GitExtensionsReferenceVersion> <!-- 'latest' or 'v3.1' (= tag from GitHub releases) or 'v3.1.0.5877' (= build number from AppVeyor)-->
+    <GitExtensionsReferenceSource>GitHub</GitExtensionsReferenceSource> <!-- 'GitHub' or 'AppVeyor' -->
+    <GitExtensionsPath>$(GitExtensionsDownloadPath)</GitExtensionsPath> <!-- for local builds (no download) -->
   </PropertyGroup>
 </Project>

--- a/src/GitExtensions.PluginManager/GitExtensions.PluginManager.nuspec
+++ b/src/GitExtensions.PluginManager/GitExtensions.PluginManager.nuspec
@@ -16,5 +16,6 @@
     <file src="../../LICENSE.md" target="/" />
     <file src="bin/$configuration$/net6.0-windows/GitExtensions.PluginManager.dll" target="lib/" />
     <file src="bin/$configuration$/net6.0-windows/PackageManager/PackageManager.UI.exe" target="lib/PackageManager/" />
+    <file src="bin/$configuration$/net6.0-windows/PackageManager.UI.runtimeconfig.json" target="lib/PackageManager/" />
   </files>
 </package>

--- a/src/GitExtensions.PluginManager/Plugin.cs
+++ b/src/GitExtensions.PluginManager/Plugin.cs
@@ -1,17 +1,14 @@
-﻿using GitExtensions.PluginManager.Properties;
-using GitUIPluginInterfaces;
-using PackageManager;
-using ResourceManager;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.ComponentModel.Composition;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
+using GitExtensions.PluginManager.Properties;
+using GitUIPluginInterfaces;
+using PackageManager;
+using ResourceManager;
 
 namespace GitExtensions.PluginManager
 {

--- a/src/PackageManager.UI/PackageManager.UI.csproj
+++ b/src/PackageManager.UI/PackageManager.UI.csproj
@@ -10,7 +10,7 @@
   
     <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>false</SelfContained>
-    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
+    <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
 

--- a/tools/Prepare-Release.ps1
+++ b/tools/Prepare-Release.ps1
@@ -21,7 +21,7 @@ function EnsureLastCommandSucceeded()
 }
 
 Write-Host "Restore solution"
-dotnet restore ..\GitExtensions.PluginManager.sln -p:RuntimeIdentifier=win-x86
+dotnet restore ..\GitExtensions.PluginManager.sln -p:RuntimeIdentifier=win-x64
 EnsureLastCommandSucceeded
 
 Write-Host "Publish PackageManager.UI"

--- a/tools/Zip-GitExtensionsPlugin.ps1
+++ b/tools/Zip-GitExtensionsPlugin.ps1
@@ -17,8 +17,9 @@ $tempPmPath = Join-Path $tempPath -ChildPath "PackageManager";
 New-Item -Force -ItemType Directory $tempPath | Out-Null;
 New-Item -Force -ItemType Directory $tempPmPath | Out-Null;
 
-Copy-Item -Force ($sourceBasePath + "\net6.0-windows\GitExtensions.PluginManager.dll") $tempPath | Out-Null;
-Copy-Item -Force ($sourceBasePath + "\net6.0-windows\PackageManager\PackageManager.UI.exe") $tempPmPath | Out-Null;
+Copy-Item -Force "$sourceBasePath\net6.0-windows\GitExtensions.PluginManager.dll" $tempPath | Out-Null;
+Copy-Item -Force "$sourceBasePath\net6.0-windows\PackageManager\PackageManager.UI.exe" $tempPmPath | Out-Null;
+Copy-Item -Force "$sourceBasePath\net6.0-windows\PackageManager.UI.runtimeconfig.json" $tempPmPath | Out-Null;
 
 Compress-Archive -Path ($tempPath + "\*") -DestinationPath $target -Force;
 Write-Host ("Created release zip at '" + $target + "'");


### PR DESCRIPTION
The Plugin Manager must target v4.0 and not the "latest", otherwise it will be targeting version higher than the release. As a result it won't be loaded by the Git Extensions app.

Resolves gitextensions/gitextensions#10548