### PR TITLE
fix: adjust build for releases

### DIFF
--- a/GitExtensions.PluginManager.sln
+++ b/GitExtensions.PluginManager.sln
@@ -35,8 +35,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		appveyor.yml = appveyor.yml
 		Directory.Build.props = Directory.Build.props
 		Directory.Build.targets = Directory.Build.targets
+		Directory.Packages.props = Directory.Packages.props
 		GitExtensions.settings = GitExtensions.settings
-		Packages.props = Packages.props
 		README.md = README.md
 	EndProjectSection
 EndProject

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 # version format
-version: 3.1.0.{build}
+version: 3.1.1.{build}
 
 matrix:
   fast_finish: true
@@ -71,14 +71,49 @@ test_script:
     dotnet test -c Release --no-restore --no-build --nologo --verbosity q --test-adapter-path:. --logger:Appveyor --logger:trx /bl:.\artifacts\logs\tests.binlog
     if ($LastExitCode -ne 0) { $host.SetShouldExit($LastExitCode) }
 
+after_test:
+- ps: |
+    # do not sign artifacts for PR to release branches, publish dev builds instead
+    if (!$env:APPVEYOR_REPO_BRANCH.StartsWith("release/") -or $env:APPVEYOR_PULL_REQUEST_TITLE) {
+        Write-Host "[INFO]: Do not sign artifacts from PR to release branch"
+        Get-ChildItem .\artifacts\GitExtensions.PluginManager*.nupkg | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
+        Get-ChildItem .\artifacts\GitExtensions.PluginManager*.zip | % { Push-AppveyorArtifact $_.FullName -FileName $_.Name }
+        Exit-AppVeyorBuild
+        return
+    }
+    else {
+        Write-Host "[INFO]: Prepare combined artifact for signing on release branch"
+        Write-Host "Creating combined build artifact ..."
+        $nupkg = (Resolve-Path .\artifacts\GitExtensions.PluginManager*.nupkg)[0].Path;
+        $zip = (Resolve-Path .\artifacts\GitExtensions.PluginManager*.zip)[0].Path;
+        $combined = ".\GitExtensions.PluginManager.$($env:APPVEYOR_BUILD_VERSION)$($env:version_suffix).combined-unsigned.zip"
+        Compress-Archive -LiteralPath $nupkg, $zip -CompressionLevel NoCompression -DestinationPath $combined -Force
+    }
+
 #---------------------------------#
 #      artifacts configuration    #
 #---------------------------------#
 
 artifacts:
-- path: .\artifacts\GitExtensions.PluginManager.*.zip
-- path: .\artifacts\GitExtensions.PluginManager.*.nupkg
+- path: .\GitExtensions.PluginManager.*.combined-unsigned.zip
 - path: .\artifacts\logs\*.binlog
+
+
+#---------------------------------#
+#      artifacts deployment       #
+#---------------------------------#
+
+deploy:
+- provider: Webhook
+  on:
+    ARTIFACT_SIGNING_ENABLED: true
+  url: https://app.signpath.io/API/v1/7c19b2cf-90f7-4d15-9b12-1b615f7c18c4/Integrations/AppVeyor?ProjectKey=gitextensions.pluginmanager&SigningPolicyKey=release-signing
+  on_build_success: true
+  on_build_failure: false
+  on_build_status_changed: false
+  method: POST
+  authorization:
+     secure: IlLI/MbhdzmXF/WB2G84zYsDWePXJqHBWDb1zBPxxXvGgx0WRxzMZxuBsvCOcZvbPTRF+UcGp0d5/HT8xZUEjA==
 
 
 # on build failure

--- a/src/GitExtensions.PluginManager/GitExtensions.PluginManager.csproj
+++ b/src/GitExtensions.PluginManager/GitExtensions.PluginManager.csproj
@@ -25,6 +25,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Include="GitExtensions.PluginManager.csproj.user" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Reference Include="GitExtensions.Extensibility">
       <HintPath>$(GitExtensionsPath)\GitExtensions.Extensibility.dll</HintPath>
     </Reference>

--- a/src/GitExtensions.PluginManager/GitExtensions.PluginManager.csproj.user
+++ b/src/GitExtensions.PluginManager/GitExtensions.PluginManager.csproj.user
@@ -3,6 +3,6 @@
     <GitExtensionsDownloadPath>..\..\..\gitextensions.shared</GitExtensionsDownloadPath> <!-- path is relative to $(ProjectDir) -->
     <GitExtensionsReferenceVersion>latest</GitExtensionsReferenceVersion> <!-- 'latest' or 'v3.1' (= tag from GitHub releases) or 'v3.1.0.5877' (= build number from AppVeyor)-->
     <GitExtensionsReferenceSource>AppVeyor</GitExtensionsReferenceSource> <!-- 'GitHub' or 'AppVeyor' -->
-    <GitExtensionsPath></GitExtensionsPath> <!-- for local builds (no download) -->
+    <GitExtensionsPath>$(GitExtensionsDownloadPath)</GitExtensionsPath> <!-- for local builds (no download) -->
   </PropertyGroup>
 </Project>

--- a/src/GitExtensions.PluginManager/GitExtensions.PluginManager.nuspec
+++ b/src/GitExtensions.PluginManager/GitExtensions.PluginManager.nuspec
@@ -16,6 +16,7 @@
     <file src="../../LICENSE.md" target="/" />
     <file src="bin/$configuration$/net9.0-windows/GitExtensions.PluginManager.dll" target="lib/" />
     <file src="bin/$configuration$/net9.0-windows/PackageManager/PackageManager.UI.exe" target="lib/PackageManager/" />
+    <file src="bin/$configuration$/net9.0-windows/PackageManager.UI.runtimeconfig.json" target="lib/PackageManager/" />
   </files>
 
-</package>
+</package>

--- a/src/GitExtensions.PluginManager/Project.Publish.targets
+++ b/src/GitExtensions.PluginManager/Project.Publish.targets
@@ -13,17 +13,27 @@
     -->
   <Target Name="_CopyPackageManager">
     <PropertyGroup>
-      <_PackageManagerSourcePath>$([MSBuild]::NormalizePath('$(RepoRoot)', 'src', 'PackageManager.UI', 'bin', '$(Configuration)', '$(TargetFramework)', '$(PackageManagerUIRuntimeIdentifier)', 'publish', 'PackageManager.UI.exe'))</_PackageManagerSourcePath>
-      <_PackageManagerTargetPath>$(_PackageManagerFolder)\PackageManager.UI.exe</_PackageManagerTargetPath>
+      <!-- Determine where PackageManager.UI.exe and PackageManager.UI.runtimeconfig.json files are -->
+      <_PackageManagerSourceDir>$([MSBuild]::NormalizePath('$(RepoRoot)', 'src', 'PackageManager.UI', 'bin', '$(Configuration)', '$(TargetFramework)', '$(PackageManagerUIRuntimeIdentifier)', 'publish'))</_PackageManagerSourceDir>
+      <_PackageManagerSourcePath>$([MSBuild]::NormalizePath('$(_PackageManagerSourceDir)', 'PackageManager.UI.exe'))</_PackageManagerSourcePath>
+      <_PackageManagerRuntimeConfigSourcePath>$([MSBuild]::NormalizePath('$(_PackageManagerSourceDir)', '..', 'PackageManager.UI.runtimeconfig.json'))</_PackageManagerRuntimeConfigSourcePath>
+
+      <!-- Determine where PackageManager.UI.exe and PackageManager.UI.runtimeconfig.json files need to be copied to -->
+      <_PackageManagerTargetPath>$(_PackageManagerFolder)/PackageManager.UI.exe</_PackageManagerTargetPath>
+      <_PackageManagerRuntimeConfigTargetPath>$(_PackageManagerFolder)/PackageManager.UI.runtimeconfig.json</_PackageManagerRuntimeConfigTargetPath>
     </PropertyGroup>
 
     <!-- Copying to we can pack it -->
     <Copy SourceFiles="$(_PackageManagerSourcePath)"
           DestinationFiles="$(TargetDir)$(_PackageManagerTargetPath)" />
+    <Copy SourceFiles="$(_PackageManagerRuntimeConfigSourcePath)"
+          DestinationFiles="$(TargetDir)$(_PackageManagerRuntimeConfigTargetPath)" />
 
     <!-- Copying to Git Extensions shared installation so we can test it locally -->
     <Copy SourceFiles="$(_PackageManagerSourcePath)"
           DestinationFiles="$(GitExtensionsPluginsPath)\$(ProjectName)\$(_PackageManagerTargetPath)" />
+    <Copy SourceFiles="$(_PackageManagerRuntimeConfigSourcePath)"
+          DestinationFiles="$(GitExtensionsPluginsPath)\$(ProjectName)\$(_PackageManagerRuntimeConfigTargetPath)" />
   </Target>
 
   <!--

--- a/test/PackageManager.Tests/ViewModels/Commands/TestCommands.cs
+++ b/test/PackageManager.Tests/ViewModels/Commands/TestCommands.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Neptuo.Observables.Commands;
 using PackageManager.Models;
 using PackageManager.Services;
 using System.Collections.Generic;


### PR DESCRIPTION
add files added in the release/3.0 branch, required since GE4.0 
Prepare for signing releases.

Also including the signing of the artifacts, for release/ branches