### PR TITLE
fix: bump GitExtensions.Extensibility to 1.0.0

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 # version format
-version: 3.1.1.{build}
+version: 3.2.0.{build}
 
 matrix:
   fast_finish: true

--- a/src/GitExtensions.PluginManager/GitExtensions.PluginManager.nuspec
+++ b/src/GitExtensions.PluginManager/GitExtensions.PluginManager.nuspec
@@ -9,7 +9,7 @@
     <tags>$tags$</tags>
     <license type="file">LICENSE.md</license>
     <dependencies>
-      <dependency id="GitExtensions.Extensibility" version="[0.4.0, 0.5.0)" />
+      <dependency id="GitExtensions.Extensibility" version="[1.0.0, 1.1.0)" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
Update GitExtensions.Extensibility to 1.0.0 to get rid of old plugins with incorrect version handling.

Depends on https://github.com/gitextensions/gitextensions.extensibility/pull/35