### PR TITLE
build: Bump version to 7.1.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,7 +16,7 @@
     <PackageVersion Include="Neptuo" Version="6.0.2" />
     <PackageVersion Include="Neptuo.Exceptions" Version="1.2.2" />
     <PackageVersion Include="Neptuo.Observables" Version="2.1.1" />
-    <PackageVersion Include="NuGet.Packaging" Version="6.8.1" />
+    <PackageVersion Include="NuGet.Packaging" Version="7.6.0" />
     <PackageVersion Include="NuGet.PackageManagement" Version="6.8.1" />
     <PackageVersion Include="System.Resources.Extensions" Version="8.0.0" />
   </ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,7 +17,7 @@
     <PackageVersion Include="Neptuo.Exceptions" Version="1.2.2" />
     <PackageVersion Include="Neptuo.Observables" Version="2.1.1" />
     <PackageVersion Include="NuGet.Packaging" Version="7.6.0" />
-    <PackageVersion Include="NuGet.PackageManagement" Version="6.8.1" />
+    <PackageVersion Include="NuGet.PackageManagement" Version="7.6.0" />
     <PackageVersion Include="System.Resources.Extensions" Version="8.0.0" />
   </ItemGroup>
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 # version format
-version: 7.0.1.{build}
+version: 7.1.0.{build}
 
 matrix:
   fast_finish: true

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 # version format
-version: 7.0.0.{build}
+version: 7.0.1.{build}
 
 matrix:
   fast_finish: true

--- a/src/GitExtensions.PluginManager/GitExtensions.PluginManager.csproj.user
+++ b/src/GitExtensions.PluginManager/GitExtensions.PluginManager.csproj.user
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <GitExtensionsDownloadPath>..\..\..\gitextensions.shared</GitExtensionsDownloadPath> <!-- path is relative to $(ProjectDir) -->
     <GitExtensionsReferenceVersion>latest</GitExtensionsReferenceVersion> <!-- 'latest' or 'v3.1' (= tag from GitHub releases) or 'v3.1.0.5877' (= build number from AppVeyor)-->
-    <GitExtensionsReferenceSource>AppVeyor</GitExtensionsReferenceSource> <!-- 'GitHub' or 'AppVeyor' -->
+    <GitExtensionsReferenceSource>GitHub</GitExtensionsReferenceSource> <!-- 'GitHub' or 'AppVeyor' -->
     <GitExtensionsPath>$(GitExtensionsDownloadPath)</GitExtensionsPath>
   </PropertyGroup>
 </Project>

--- a/src/PackageManager.NuGet/Models/NuGetPackageSourceCollection.cs
+++ b/src/PackageManager.NuGet/Models/NuGetPackageSourceCollection.cs
@@ -67,9 +67,29 @@ namespace PackageManager.Models
                 return;
 
             if (source == null)
-                Provider.SaveActivePackageSource(null);
+                ClearActivePackageSource();
             else
                 Provider.SaveActivePackageSource(UnWrap(source));
+        }
+
+        private void ClearActivePackageSource()
+        {
+            if (Provider is not PackageSourceProvider concreteProvider)
+            {
+                return;
+            }
+
+            if (concreteProvider.Settings.GetSection("activePackageSource") is not { } section)
+            {
+                return;
+            }
+
+            foreach (SettingItem item in section.Items)
+            {
+                concreteProvider.Settings.Remove("activePackageSource", item);
+            }
+
+            concreteProvider.Settings.SaveToDisk();
         }
 
         internal void SavePackageSources(bool isOrderChanged = false)


### PR DESCRIPTION
Bump PM version to 7.0.1 in order to integrate the final GitExtensions.Extensibility v7.0.0 API.